### PR TITLE
Optimize SPDX comparer for performance

### DIFF
--- a/src/main/java/org/spdx/tools/compare/AbstractFileCompareSheet.java
+++ b/src/main/java/org/spdx/tools/compare/AbstractFileCompareSheet.java
@@ -20,6 +20,9 @@ package org.spdx.tools.compare;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.stream.IntStream;
 
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellStyle;
@@ -53,6 +56,7 @@ public abstract class AbstractFileCompareSheet extends AbstractSheet {
 	private static final int MAX_VALUE_LENGTH = 32000;
 
 	private NormalizedFileNameComparator normalizedFileNameComparator = new NormalizedFileNameComparator();
+	private ConcurrentMap<String, Boolean> comparisonCache = new ConcurrentHashMap<>();
 
 	/**
 	 * @param workbook


### PR DESCRIPTION
Optimize performance of SPDXComparer by improving data structures, caching, and parallel processing.

* **AbstractFileCompareSheet.java**
  - Import concurrent data structures and parallel streams.
  - Add caching for comparison results.
* **CompareHelper.java**
  - Import concurrent data structures and parallel streams.
  - Add caching for checksum, annotation, and relationship conversions.
  - Use parallel streams for string conversions.
* **MultiDocumentSpreadsheet.java**
  - Import concurrent data structures and parallel streams.
  - Add caching for file collections.
  - Use parallel streams for file collection and sorting.
* **DocumentSheet.java**
  - Import concurrent data structures and parallel streams.
  - Add caching for comparison results.
  - Use parallel streams for importing comparison results.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/im-customers-arm/arm-tools-java/pull/1?shareId=c1b5d333-5e79-40de-8f99-e025487c37ad).