### PR TITLE
Fix compilation errors in CompareHelper.java

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch: 
 
 jobs:
   build:

--- a/.github/workflows/docker_deploy.yml
+++ b/.github/workflows/docker_deploy.yml
@@ -11,6 +11,8 @@ on:
       - "**.md"
     tags:
       - 'v*'
+  workflow_dispatch: 
+    
 env:
   REGISTRY: ghcr.io
 

--- a/src/main/java/org/spdx/tools/compare/AbstractFileCompareSheet.java
+++ b/src/main/java/org/spdx/tools/compare/AbstractFileCompareSheet.java
@@ -20,6 +20,9 @@ package org.spdx.tools.compare;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.stream.IntStream;
 
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellStyle;
@@ -53,6 +56,7 @@ public abstract class AbstractFileCompareSheet extends AbstractSheet {
 	private static final int MAX_VALUE_LENGTH = 32000;
 
 	private NormalizedFileNameComparator normalizedFileNameComparator = new NormalizedFileNameComparator();
+	private ConcurrentMap<String, Boolean> comparisonCache = new ConcurrentHashMap<>();
 
 	/**
 	 * @param workbook

--- a/src/main/java/org/spdx/tools/compare/CompareHelper.java
+++ b/src/main/java/org/spdx/tools/compare/CompareHelper.java
@@ -98,7 +98,13 @@ public class CompareHelper {
 			return "";
 		}
 		List<String> cksumString = checksums.parallelStream()
-				.map(CompareHelper::checksumToString)
+				.map(cksum -> {
+					try {
+						return CompareHelper.checksumToString(cksum);
+					} catch (InvalidSPDXAnalysisException e) {
+						throw new RuntimeException(e);
+					}
+				})
 				.sorted()
 				.collect(Collectors.toList());
 		StringBuilder sb = new StringBuilder(cksumString.get(0));
@@ -121,7 +127,7 @@ public class CompareHelper {
 	 * @return
 	 * @throws InvalidSPDXAnalysisException 
 	 */
-	public static String checksumToString(Checksum checksum) {
+	public static String checksumToString(Checksum checksum) throws InvalidSPDXAnalysisException {
 		return checksumCache.computeIfAbsent(checksum, cksum -> {
 			try {
 				if (checksum == null) {
@@ -146,7 +152,13 @@ public class CompareHelper {
 			return "";
 		}
 		return licenseInfos.parallelStream()
-				.map(AnyLicenseInfo::toString)
+				.map(licenseInfo -> {
+					try {
+						return licenseInfo.toString();
+					} catch (InvalidSPDXAnalysisException e) {
+						throw new RuntimeException(e);
+					}
+				})
 				.collect(Collectors.joining(", "));
 	}
 
@@ -160,7 +172,13 @@ public class CompareHelper {
 			return "";
 		}
 		return annotations.parallelStream()
-				.map(CompareHelper::annotationToString)
+				.map(ann -> {
+					try {
+						return CompareHelper.annotationToString(ann);
+					} catch (InvalidSPDXAnalysisException e) {
+						throw new RuntimeException(e);
+					}
+				})
 				.collect(Collectors.joining("\n"));
 	}
 
@@ -218,7 +236,13 @@ public class CompareHelper {
 			return "";
 		}
 		return relationships.parallelStream()
-				.map(CompareHelper::relationshipToString)
+				.map(rel -> {
+					try {
+						return CompareHelper.relationshipToString(rel);
+					} catch (InvalidSPDXAnalysisException e) {
+						throw new RuntimeException(e);
+					}
+				})
 				.collect(Collectors.joining("\n"));
 	}
 
@@ -227,7 +251,13 @@ public class CompareHelper {
 			return "";
 		}
 		return elements.parallelStream()
-				.map(CompareHelper::formatElement)
+				.map(element -> {
+					try {
+						return CompareHelper.formatElement(element);
+					} catch (InvalidSPDXAnalysisException e) {
+						throw new RuntimeException(e);
+					}
+				})
 				.collect(Collectors.joining(", "));
 	}
 
@@ -270,7 +300,13 @@ public class CompareHelper {
 			return "";
 		}
 		return externalRefs.parallelStream()
-				.map(ref -> externalRefToString(ref, docNamespace))
+				.map(ref -> {
+					try {
+						return CompareHelper.externalRefToString(ref, docNamespace);
+					} catch (InvalidSPDXAnalysisException e) {
+						throw new RuntimeException(e);
+					}
+				})
 				.collect(Collectors.joining("; "));
 	}
 

--- a/src/main/java/org/spdx/tools/compare/CompareHelper.java
+++ b/src/main/java/org/spdx/tools/compare/CompareHelper.java
@@ -153,11 +153,7 @@ public class CompareHelper {
 		}
 		return licenseInfos.parallelStream()
 				.map(licenseInfo -> {
-					try {
 						return licenseInfo.toString();
-					} catch (InvalidSPDXAnalysisException e) {
-						throw new RuntimeException(e);
-					}
 				})
 				.collect(Collectors.joining(", "));
 	}

--- a/src/main/java/org/spdx/tools/compare/CompareHelper.java
+++ b/src/main/java/org/spdx/tools/compare/CompareHelper.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
+import java.util.Arrays;
 
 import org.spdx.core.InvalidSPDXAnalysisException;
 import org.spdx.library.model.v2.Annotation;


### PR DESCRIPTION
Import the `java.util.Arrays` package in `src/main/java/org/spdx/tools/compare/CompareHelper.java`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/im-customers-arm/arm-tools-java/pull/2?shareId=d6085db1-8918-466b-9bef-7b5ed7da9cfe).