### PR TITLE
Added deterministic conversion

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+name: Release jar
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: Tag to attach the jar to
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  build-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+      - name: Cache Maven packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Build jar
+        run: mvn --batch-mode -DskipTests package
+      - name: Prepare release asset
+        id: prep
+        run: |
+          VERSION=$(mvn -q -DforceStdout help:evaluate -Dexpression=project.version)
+          JAR=target/tools-java-${VERSION}-jar-with-dependencies.jar
+          if [[ ! -f "$JAR" ]]; then
+            echo "Jar not found: $JAR" >&2
+            exit 1
+          fi
+          ASSET=tools-java-${VERSION}.jar
+          cp "$JAR" "$ASSET"
+          echo "asset=$ASSET" >> "$GITHUB_OUTPUT"
+      - name: Upload release asset
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ inputs.tag_name }}
+          files: ${{ steps.prep.outputs.asset }}

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Example to convert a SPDX file from Tag to RDF format:
 
     java -jar tools-java-2.0.2-jar-with-dependencies.jar Convert ../testResources/SPDXTagExample-v2.2.spdx TagToRDF.rdf
 
-The file formats can optionally be provided as the 3rd and 4th parameter for the input and output formats respectively.  An optional 5th option `excludeLicenseDetails` will not copy the listed license properties to the output file.  The following example will copy a JSON format to an RDF Turtle format without including the listed license properties:
+The file formats can optionally be provided as the 3rd and 4th parameter for the input and output formats respectively.  An optional 5th option `excludeLicenseDetails` will not copy the listed license properties to the output file.  An additional optional flag `--stable-ids` makes SPDX 2 to SPDX 3 conversions deterministic by preserving SPDX IDs when possible and otherwise using deterministic IDs. The following example will copy a JSON format to an RDF Turtle format without including the listed license properties:
 
     java -jar tools-java-2.0.2-jar-with-dependencies.jar Convert ../testResources/SPDXTagExample-v2.2.spdx TagToRDF.ttl TAG RDFTTL excludeLicenseDetails
 
@@ -66,6 +66,10 @@ To convert from SPDX 2 to SPDX 3.0.1:
 * or add the options for the from and to file types:
 
     java -jar tools-java-2.0.2-jar-with-dependencies.jar Convert hello.spdx hello.spdx.json TAG JSONLD
+
+To convert from SPDX 2 to SPDX 3.0.1 with deterministic SPDX IDs:
+
+    java -jar tools-java-2.0.2-jar-with-dependencies.jar Convert hello.spdx hello.spdx.json TAG JSONLD --stable-ids
 
 ## Compare utilities
 

--- a/src/main/java/org/spdx/tools/DeterministicSpdxIdHelper.java
+++ b/src/main/java/org/spdx/tools/DeterministicSpdxIdHelper.java
@@ -1,0 +1,56 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.spdx.tools;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+final class DeterministicSpdxIdHelper {
+	static final String STABLE_IDS_FLAG = "--stable-ids";
+	private static final String FALLBACK_PREFIX = "SPDXRef-";
+	private static final int HASH_HEX_LEN = 16;
+	private static final String V3_ID_PATTERN = "^[A-Za-z0-9._-]+$";
+
+	private DeterministicSpdxIdHelper() {
+		// Utility class.
+	}
+
+	static boolean isStableIdsFlag(String arg) {
+		return STABLE_IDS_FLAG.equalsIgnoreCase(arg);
+	}
+
+	static boolean isValidV3Id(String id) {
+		if (id == null) {
+			return false;
+		}
+		String trimmed = id.trim();
+		return !trimmed.isEmpty() && trimmed.matches(V3_ID_PATTERN);
+	}
+
+	static String deterministicFallbackId(String fromObjectUri) {
+		String input = fromObjectUri == null ? "" : fromObjectUri;
+		String hex = sha256Hex(input);
+		if (hex.length() > HASH_HEX_LEN) {
+			hex = hex.substring(0, HASH_HEX_LEN);
+		}
+		return FALLBACK_PREFIX + hex;
+	}
+
+	private static String sha256Hex(String input) {
+		try {
+			MessageDigest digest = MessageDigest.getInstance("SHA-256");
+			byte[] hashed = digest.digest(input.getBytes(StandardCharsets.UTF_8));
+			StringBuilder builder = new StringBuilder(hashed.length * 2);
+			for (byte value : hashed) {
+				builder.append(String.format("%02x", value));
+			}
+			return builder.toString();
+		} catch (NoSuchAlgorithmException e) {
+			throw new RuntimeException("SHA-256 not available", e);
+		}
+	}
+}

--- a/src/main/java/org/spdx/tools/SpdxConverter.java
+++ b/src/main/java/org/spdx/tools/SpdxConverter.java
@@ -98,6 +98,24 @@ public class SpdxConverter {
 				}
 			}
 		}
+		// Handle the case where the fourth argument is an option flag rather than a file type.
+		// In this situation, treat it like the 3-argument-with-option form and ignore any
+		// explicitly specified input file type, for consistency with the 3-argument handling.
+		if (args.length == 4 && isOptionArg(args[3])) {
+			if (isExcludeLicenseDetails(args[3])) {
+				excludeLicenseDetails = true;
+			}
+			if (DeterministicSpdxIdHelper.isStableIdsFlag(args[3])) {
+				stableIds = true;
+			}
+			try {
+				convert(args[0], args[1], excludeLicenseDetails, stableIds);
+			} catch (SpdxConverterException e) {
+				System.err.println("Error converting: "+e.getMessage());
+				System.exit(ERROR_STATUS);
+			}
+			return;
+		}
 		if (args.length < 4) {
 			try {
 				convert(args[0], args[1], excludeLicenseDetails, stableIds);

--- a/src/test/java/org/spdx/tools/SpdxConverterTestV3.java
+++ b/src/test/java/org/spdx/tools/SpdxConverterTestV3.java
@@ -14,6 +14,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.junit.After;
 import org.junit.Before;
@@ -117,6 +118,25 @@ public class SpdxConverterTestV3 extends TestCase {
 		assertEquals("http://spdx.org/spdxdocs/spdx-tools-v1.2-3F2504E0-4F89-41D3-9A0C-0305E82C3301#", map.get().getNamespace());
 		assertEquals("DocumentRef-spdx-tool-1.2", map.get().getPrefix());
 		// TODO: create a more extensive set of checks
+	}
+
+	public void testV2JsonToV3JsonLDStableIds() throws SpdxConverterException, InvalidSPDXAnalysisException, IOException {
+		Path outFilePath1 = tempDirPath.resolve("result-stable-1.jsonld");
+		Path outFilePath2 = tempDirPath.resolve("result-stable-2.jsonld");
+		SpdxConverter.convert(TEST_JSON_FILE_PATH, outFilePath1.toString(), SerFileType.JSON, SerFileType.JSONLD, false, true);
+		SpdxConverter.convert(TEST_JSON_FILE_PATH, outFilePath2.toString(), SerFileType.JSON, SerFileType.JSONLD, false, true);
+		SpdxDocument resultDoc1 = SpdxToolsHelper.deserializeDocument(outFilePath1.toFile(), SerFileType.JSONLD);
+		SpdxDocument resultDoc2 = SpdxToolsHelper.deserializeDocument(outFilePath2.toFile(), SerFileType.JSONLD);
+		assertEquals(resultDoc1.getId(), resultDoc2.getId());
+		List<String> rootIds1 = resultDoc1.getRootElements().stream()
+				.map(Element::getId)
+				.sorted()
+				.collect(Collectors.toList());
+		List<String> rootIds2 = resultDoc2.getRootElements().stream()
+				.map(Element::getId)
+				.sorted()
+				.collect(Collectors.toList());
+		assertEquals(rootIds1, rootIds2);
 	}
 
 }


### PR DESCRIPTION
This pull request introduces a new feature to support deterministic SPDX ID generation when converting SPDX 2 documents to SPDX 3, via a new `--stable-ids` flag. The changes include enhancements to the command-line interface, core conversion logic, and documentation, along with new tests to verify deterministic behavior.

**New Feature: Deterministic SPDX IDs for SPDX 2 to 3 Conversion**

* Added a `--stable-ids` flag to the converter CLI, allowing users to preserve SPDX IDs when possible or generate deterministic IDs during SPDX 2 to 3 conversions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L59-R59) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R70-R73) [[3]](diffhunk://#diff-6fa543c0acb0234e692adfc59d664c8b8f47e431bc1248d1c618c67ff29f3269L76-R103) [[4]](diffhunk://#diff-6fa543c0acb0234e692adfc59d664c8b8f47e431bc1248d1c618c67ff29f3269L110-R128) [[5]](diffhunk://#diff-6fa543c0acb0234e692adfc59d664c8b8f47e431bc1248d1c618c67ff29f3269R143-R155) [[6]](diffhunk://#diff-6fa543c0acb0234e692adfc59d664c8b8f47e431bc1248d1c618c67ff29f3269L137-R168) [[7]](diffhunk://#diff-6fa543c0acb0234e692adfc59d664c8b8f47e431bc1248d1c618c67ff29f3269L150-R181) [[8]](diffhunk://#diff-6fa543c0acb0234e692adfc59d664c8b8f47e431bc1248d1c618c67ff29f3269R196-R210) [[9]](diffhunk://#diff-6fa543c0acb0234e692adfc59d664c8b8f47e431bc1248d1c618c67ff29f3269L207-R253) [[10]](diffhunk://#diff-6fa543c0acb0234e692adfc59d664c8b8f47e431bc1248d1c618c67ff29f3269L288-R334) [[11]](diffhunk://#diff-6fa543c0acb0234e692adfc59d664c8b8f47e431bc1248d1c618c67ff29f3269R375-R453) [[12]](diffhunk://#diff-6fa543c0acb0234e692adfc59d664c8b8f47e431bc1248d1c618c67ff29f3269R483-R491)

**Implementation Details**

* Introduced the utility class `DeterministicSpdxIdHelper` to encapsulate logic for validating IDs and generating deterministic fallback SPDX IDs using SHA-256 hashing.
* Updated the conversion pipeline to pass the new `stableIds` flag and apply stable ID logic during SPDX 2 to 3 conversions. [[1]](diffhunk://#diff-6fa543c0acb0234e692adfc59d664c8b8f47e431bc1248d1c618c67ff29f3269L76-R103) [[2]](diffhunk://#diff-6fa543c0acb0234e692adfc59d664c8b8f47e431bc1248d1c618c67ff29f3269L110-R128) [[3]](diffhunk://#diff-6fa543c0acb0234e692adfc59d664c8b8f47e431bc1248d1c618c67ff29f3269R143-R155) [[4]](diffhunk://#diff-6fa543c0acb0234e692adfc59d664c8b8f47e431bc1248d1c618c67ff29f3269L137-R168) [[5]](diffhunk://#diff-6fa543c0acb0234e692adfc59d664c8b8f47e431bc1248d1c618c67ff29f3269L150-R181) [[6]](diffhunk://#diff-6fa543c0acb0234e692adfc59d664c8b8f47e431bc1248d1c618c67ff29f3269R196-R210) [[7]](diffhunk://#diff-6fa543c0acb0234e692adfc59d664c8b8f47e431bc1248d1c618c67ff29f3269L207-R253) [[8]](diffhunk://#diff-6fa543c0acb0234e692adfc59d664c8b8f47e431bc1248d1c618c67ff29f3269L288-R334) [[9]](diffhunk://#diff-6fa543c0acb0234e692adfc59d664c8b8f47e431bc1248d1c618c67ff29f3269R375-R453)
* Refactored option parsing and usage documentation to include the new flag and clarify its effect. [[1]](diffhunk://#diff-6fa543c0acb0234e692adfc59d664c8b8f47e431bc1248d1c618c67ff29f3269L58-R61) [[2]](diffhunk://#diff-6fa543c0acb0234e692adfc59d664c8b8f47e431bc1248d1c618c67ff29f3269R483-R491)

**Testing**

* Added a new test `testV2JsonToV3JsonLDStableIds` to verify that repeated conversions with the `--stable-ids` flag produce identical SPDX IDs in the output.

**Documentation**

* Updated the `README.md` with usage instructions and examples for the new `--stable-ids` flag. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L59-R59) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R70-R73)

These changes make SPDX document conversions more predictable and reproducible, especially when upgrading from SPDX 2 to 3.