### PR TITLE
Add SPDX2 stable-id fixture auto-discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,10 @@ You need [Apache Maven](http://maven.apache.org/) to build the project:
 
     mvn clean install
 
+### Test fixtures
+
+SPDX 2 to SPDX 3 stable-ID conversion fixtures live in `testResources/spdx2tospdx3conversion` and are auto-discovered by the unit tests. Add new SPDX2 files to that folder to extend coverage.
+
 ## Contributing
 
 See the file [CONTRIBUTING.md](./CONTRIBUTING.md) for information on

--- a/testResources/spdx2tospdx3conversion/source-conversion-spdx2.json
+++ b/testResources/spdx2tospdx3conversion/source-conversion-spdx2.json
@@ -1,0 +1,5705 @@
+{
+  "files": [
+    {
+      "fileName": "./requirements.txt",
+      "SPDXID": "SPDXRef-File--requirements.txt-92F50CBE2B01F83F6A3E25BDDF2CEBEFF743A0E0",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "b251603e2d912b5b9ae8c8beafcdc0322df50d1e91ec5debd02661d02cd3b870"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "92f50cbe2b01f83f6a3e25bddf2cebeff743a0e0"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./SECURITY.md",
+      "SPDXID": "SPDXRef-File--SECURITY.md-FA533283215D0BA141A7A28AC0D4FDC8089E3F0B",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ba9643955bfcb04524a6fe5a8c2929b54abc2e67bb3480ce806e742d506e4dc9"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "fa533283215d0ba141a7a28ac0d4fdc8089e3f0b"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./README.md",
+      "SPDXID": "SPDXRef-File--README.md-A3163A0CAC9F443EDF625648EFE70C3D365E6CDB",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "bf1f0422f17c7d5a3007d3f78b79408545615b335dd4b19b75ffde0f644657fa"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "a3163a0cac9f443edf625648efe70c3d365e6cdb"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.clang-format",
+      "SPDXID": "SPDXRef-File--.clang-format-6B5CD29FB1194B199BF9F6C37BF9234CF43E63C6",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "fff221e718d21da42d5d716dd08b7ec37c7ddc167d3c8bae879f02f877c52efb"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6b5cd29fb1194b199bf9f6c37bf9234cf43e63c6"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.readthedocs.yaml",
+      "SPDXID": "SPDXRef-File--.readthedocs.yaml-71E0A36B7643334D48EAD0A3C865120841629A5C",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "2d6afb1ce91c5f9ec5cd2469290f4156716253c59c5fda582b0338194f196ce6"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "71e0a36b7643334d48ead0a3c865120841629a5c"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.codeclimate.yml",
+      "SPDXID": "SPDXRef-File--.codeclimate.yml-B2CEE30FD5E2C2BB525F0019546094B4F2C6921A",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "5eb0e16e0933f6d26da0074f6914699f284b4b1bc24dd2d7a7dfcdc877920ac3"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b2cee30fd5e2c2bb525f0019546094b4f2c6921a"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./documentation/license_link.rst",
+      "SPDXID": "SPDXRef-File--documentation-license-link.rst-6E2E46EF9CA8EF0F8BBC0A3011BF6DF1B6578277",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "b6baeaa8aad43591b8ff2804e6da9c79fd60db0a1129056d3a743612f42f71de"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6e2e46ef9ca8ef0f8bbc0a3011bf6df1b6578277"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./documentation/manual/file_csc.rst",
+      "SPDXID": "SPDXRef-File--documentation-manual-file-csc.rst-A2DD41175AABDAD3A7D86428A646B514ACF6A927",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "5dd78ab811d5caa7b1bcbaf9386c79f8c66bb48cf22f116b7d3cddd7c039d915"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "a2dd41175aabdad3a7d86428a646b514acf6a927"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./documentation/cmake/FindSPHINX.cmake",
+      "SPDXID": "SPDXRef-File--documentation-cmake-FindSPHINX.cmake-523D03A6BBE1572A7935FFBC0473978AD99CE48A",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "57f9aae4cc22eb6b93a3e10340e80d673694aece7c77d3ac2d72b91a9f06b0c7"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "523d03a6bbe1572a7935ffbc0473978ad99ce48a"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/demos/project-gearshift-demo-scenario-integrationtests.md",
+      "SPDXID": "SPDXRef-File--docs-demos-project-gearshift-demo-scenario-integrationtests.md-96ABDE387BBCF05CED314CA2BB066EADB5D2E275",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "5bddd4cfa77245312ef980364786a03ed9d9e95f4440468f5d5283d3a02c6bad"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "96abde387bbcf05ced314ca2bb066eadb5d2e275"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/strictdoc/02_fsc_lite.sdoc",
+      "SPDXID": "SPDXRef-File--docs-strictdoc-02-fsc-lite.sdoc-441C5B9C5D87EF26CED32BC31FFDC5EECB6D5015",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "35fb170fe9dcd3df936d4e22c2904bd279aae1a6e8d619f56ef36980e1beb227"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "441c5b9c5d87ef26ced32bc31ffdc5eecb6d5015"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/strictdoc/evidence/EVID-007-deploy-message-chunking.txt",
+      "SPDXID": "SPDXRef-File--docs-strictdoc-evidence-EVID-007-deploy-message-chunking.txt-7B87AFED92003513E09735899EBE88E7B795D704",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "57dadd1930cea2c4fb015575b7df8a2fd6090b4f08e04d1b45c8d78a9767ce9d"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "7b87afed92003513e09735899ebe88e7b795d704"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/strictdoc/evidence/EVID-010-libcam-protocol-sequence.txt",
+      "SPDXID": "SPDXRef-File--docs-strictdoc-evidence-EVID-010-libcam-protocol-sequence.txt-EA033D404B5307566EF0D8C3CC6609D742428803",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "fc96a46e1f5de2f2b9369a5b088b29c22fcec48f61dee6d5e56fc0053598a648"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "ea033d404b5307566ef0d8c3cc6609d742428803"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/screencast-recordings/ScreencastUpdated.mp4",
+      "SPDXID": "SPDXRef-File--docs-screencast-recordings-ScreencastUpdated.mp4-5A1C1A319126ED0718432FC79534069491EBBDA3",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "134c1085f9084040aa897c7561d1fadb7ab8dc31244f438fa0b0aeee36598cd8"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "5a1c1a319126ed0718432fc79534069491ebbda3"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.github/workflows/build-cam-app_exper.yml",
+      "SPDXID": "SPDXRef-File--.github-workflows-build-cam-app-exper.yml-92C4B65CEA547955179D00C1E31DC235ED7D971E",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "cc0908b53d2d5aa0c42b7cfc1bd17a3beb42b2be4e8d0386526a01caa256b3c1"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "92c4b65cea547955179d00c1e31dc235ed7d971e"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.github/workflows/corellium-saas.yaml",
+      "SPDXID": "SPDXRef-File--.github-workflows-corellium-saas.yaml-2331229D101363C470F8F1EAE01639C27D709AC7",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "3fdb1f37065f4a84ba44f0fa9c140d567ca3df4833460eff83e15434241b10aa"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "2331229d101363c470f8f1eae01639c27d709ac7"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./test/fixture/calibration_invalid_analyze.csel",
+      "SPDXID": "SPDXRef-File--test-fixture-calibration-invalid-analyze.csel-678DCFAE77E7B59A602C5B755A6028A01BAF9627",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "68a46b41f5da9d4e3414bedc48ad7b2059d4221b04dc70023de9703952137457"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "678dcfae77e7b59a602c5b755a6028a01baf9627"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./test/fixture/99085ddc-bc10-11ed-9a44-7ef9696e0001.csc.yml",
+      "SPDXID": "SPDXRef-File--test-fixture-99085ddc-bc10-11ed-9a44-7ef9696e0001.csc.yml-66A179E3CC4CA4E7A972F77C65988C623B4FB208",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "5474b43a3445383156fb41d50129558048d1a40c0c9a4261521734223d46ede1"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "66a179e3cc4ca4e7a972f77c65988c623b4fb208"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./CMakeLists.txt",
+      "SPDXID": "SPDXRef-File--CMakeLists.txt-35A4BFDCBEAC91A1CA69AE2971DD7742A3341EE0",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "c35c0919aa86c23df3bbeedcb9ec0f23b821f088fba5806b00c2b74c6749e481"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "35a4bfdcbeac91a1ca69ae2971dd7742a3341ee0"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.gitignore",
+      "SPDXID": "SPDXRef-File--.gitignore-8A015813F7BDBDBB99B4286A32A03D41F2F803BF",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "a76e2548a45d5140d2c69f73d31852f79244dac1c4f3d7458762a877a100baab"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "8a015813f7bdbdbb99b4286a32a03d41f2f803bf"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./documentation/release_notes.rst",
+      "SPDXID": "SPDXRef-File--documentation-release-notes.rst-828594325069BC7100CB59B7413DA26D7190CD15",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "cb23441bc84fce44945aee983417fb1f3802d1ab796d9c7b164ec3807dccb33f"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "828594325069bc7100cb59b7413da26d7190cd15"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./documentation/_static/css/custom.css",
+      "SPDXID": "SPDXRef-File--documentation--static-css-custom.css-24A745E0C2B3A8C5DEBD4340571F895AAC3A96F2",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "d18fc2d6d8615e8cb1486068b26535e7f6ba46b523d1896bfc1c98c711ea76d5"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "24a745e0c2b3a8c5debd4340571f895aac3a96f2"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./documentation/images/fault_injection.svg",
+      "SPDXID": "SPDXRef-File--documentation-images-fault-injection.svg-85911D560DBF135B6635C5E669BB6A0571E69398",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "71dbb0739fca3076b51bae79e730a1b1a06c58b9bc75bc93f765f4155700c514"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "85911d560dbf135b6635c5e669bb6a0571e69398"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/demos/project-gearshift-demo-scenario-unittests.md",
+      "SPDXID": "SPDXRef-File--docs-demos-project-gearshift-demo-scenario-unittests.md-2048CB17747D80661512FEF0560836E15259387E",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "3fbbc89cb13ce0650db6c3da97205cc439f6909394850c7dfaaa07e794d94790"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "2048cb17747d80661512fef0560836e15259387e"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/strictdoc/cam_fusa.sgra",
+      "SPDXID": "SPDXRef-File--docs-strictdoc-cam-fusa.sgra-F51F528801ACABD35CD92B4B2824F6419FCF78B6",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "46b47a99318a778e801547932f0d52f101f68e40f845be13b5a898735905c0f1"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "f51f528801acabd35cd92b4b2824f6419fcf78b6"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/strictdoc/demo-script.md",
+      "SPDXID": "SPDXRef-File--docs-strictdoc-demo-script.md-A409B1CA88D6E07E575411B260D4BE6BBAD680A8",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "d2ae8d476e4df6b2c74526fc4eb8c767e144bd57194ca097b796f0aac6ab4cb0"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "a409b1ca88d6e07e575411b260d4be6bbad680a8"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/strictdoc/evidence/EVID-001-temporal-fault-detection.txt",
+      "SPDXID": "SPDXRef-File--docs-strictdoc-evidence-EVID-001-temporal-fault-detection.txt-1375D89BF1BF435171B2EAE4334E24781601E5BB",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "e85c685e0ce93bd6956bcb3c9a0d5560763dccb2dc3a6ce94fda34bbc032d48d"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "1375d89bf1bf435171b2eae4334e24781601e5bb"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/screencast-recordings/CAMDemo_Automation_results.mp4",
+      "SPDXID": "SPDXRef-File--docs-screencast-recordings-CAMDemo-Automation-results.mp4-03D57D5CE2FC70D330C1757A0CEFFB1C9924E3FB",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "360705509fb2bdcb23e30c3fbd4c8fd1d0f72d45fd403f163ec78e58eb470343"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "03d57d5ce2fc70d330c1757a0ceffb1c9924e3fb"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.github/workflows/automated-kas-setup.yml",
+      "SPDXID": "SPDXRef-File--.github-workflows-automated-kas-setup.yml-13233442371BD36EEFAB2CFC0DD53DEE3591EA34",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "faa0b0a370ae8361768f413dc926d651d0a0e6054a41d69c83e9824ec6c1a068"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "13233442371bd36eefab2cfc0dd53dee3591ea34"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.github/workflows/Kronos-Latest.yaml",
+      "SPDXID": "SPDXRef-File--.github-workflows-Kronos-Latest.yaml-5637276E7856B01BF8E43E24F916D6B16E65356B",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "282bff12556c58ea1f3d36048bdc9e7978936f53493a62603cdee89fb95fac37"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "5637276e7856b01bf8e43e24f916d6b16e65356b"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./test/conftest.py",
+      "SPDXID": "SPDXRef-File--test-conftest.py-1CAFCFB361A995F4D9A342D260548E9F184C211D",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "2a88cc56d42d0ff65239d822ddedb35b947c4db8c4c3439ff33d9c551d6bf774"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "1cafcfb361a995f4d9a342d260548e9f184c211d"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./test/fixture/99085ddc-bc10-11ed-9a44-7ef9696e0001.csd",
+      "SPDXID": "SPDXRef-File--test-fixture-99085ddc-bc10-11ed-9a44-7ef9696e0001.csd-DECB406C982A00276FA967201C9B8331FBB8C8B6",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "915d26f3c6a9bce19ccb2a1d5c138f5856f5eaadef1215d4f408d5818438ce1d"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "decb406c982a00276fa967201c9b8331fbb8c8b6"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./license.rst",
+      "SPDXID": "SPDXRef-File--license.rst-D9C974B17783DCD346D897432773DD17C231E26A",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "7bf2c6e1b50a20702e79ef3905bdcd1f11db5dd06577f2129e69e977540f63bd"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "d9c974b17783dcd346d897432773dd17c231e26a"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.dictionary",
+      "SPDXID": "SPDXRef-File--.dictionary-291994BFD92EAE2A2BA5C7A0269B3F98E2909142",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "dca1577e648590f704138af77f5676e20401dbb3583db02f42c855b4460215e2"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "291994bfd92eae2a2ba5c7a0269b3f98e2909142"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./documentation/overview.rst",
+      "SPDXID": "SPDXRef-File--documentation-overview.rst-58549620111F13EF590623AF4C84BB521818DAEA",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "5aff32931ff67dc147f13c77bdab9ac3ae4a511a5b0a213ff42daf3d0d7e5c7e"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "58549620111f13ef590623af4c84bb521818daea"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./documentation/manual/file_csel.rst",
+      "SPDXID": "SPDXRef-File--documentation-manual-file-csel.rst-F549E6C548D67CC78320C480B3C2201233026374",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "d0236906561da749427dd19357280b872972ae0d7f053620d055014f4c53a9d5"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "f549e6c548d67cc78320c480b3c2201233026374"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./documentation/images/cam_overview.svg",
+      "SPDXID": "SPDXRef-File--documentation-images-cam-overview.svg-43A589CA729079E8A986BA477D6CA04B230B775C",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "5bc672e9cc557ba3d9baa8ec3b673fd3edc9e64d71347707a1f00dade5c7496a"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "43a589ca729079e8a986ba477d6ca04b230b775c"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/demos/project-gearshift-demo-scenario-appsecurity-ghas.md",
+      "SPDXID": "SPDXRef-File--docs-demos-project-gearshift-demo-scenario-appsecurity-ghas.md-627EFF5DA7CBFC54615C036115E32798FF5FFD26",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "654796074ce6b95190f91828df03f17e1558ad3959d5d07b93674dccec5601e1"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "627eff5da7cbfc54615c036115e32798ff5ffd26"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/strictdoc/01_hara_lite.sdoc",
+      "SPDXID": "SPDXRef-File--docs-strictdoc-01-hara-lite.sdoc-60AD39D89246C86E24477722959BBC06363F7E16",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "c81adbe95f6d20e129d4eb509010b9a6adf0085139ead7f79d59196017ad8bc8"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "60ad39d89246c86e24477722959bbc06363f7e16"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/strictdoc/06_verification_plan.sdoc",
+      "SPDXID": "SPDXRef-File--docs-strictdoc-06-verification-plan.sdoc-222C8219081AA7FABFCC5A004DB677153080A619",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "c0a50a81c5e93637c327b440079320d255b715fdadfffbf78d7f59031c2ea848"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "222c8219081aa7fabfcc5a004db677153080a619"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/strictdoc/evidence/EVID-008-future-timestamp-rejection.txt",
+      "SPDXID": "SPDXRef-File--docs-strictdoc-evidence-EVID-008-future-timestamp-rejection.txt-708DA0856E63041F222573088402A4DD2430FBF1",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "05ff5943d3f92b1552dc67f5610fc185c4176a6810e640eb1357642a79203a4a"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "708da0856e63041f222573088402a4dd2430fbf1"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/screencast-recordings/Introduction_Navigation_Recording.mp4",
+      "SPDXID": "SPDXRef-File--docs-screencast-recordings-Introduction-Navigation-Recording.mp4-31986C4CDE5C1618B869675195AD67EEB5B4D378",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "e3b03a288393e018366501d1b3047e0ebef87e3c2a46d33be36ee262b1b3d5ca"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "31986c4cde5c1618b869675195ad67eeb5b4d378"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.github/workflows/strictdoc-export.yml",
+      "SPDXID": "SPDXRef-File--.github-workflows-strictdoc-export.yml-28E30D129435BE2720AE8698E0AA1DE260374E8A",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "f1e6d7fad8d9eba1b7a1437d72874eec714b8e7cfc5c750f8e5bb436b15bb29a"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "28e30d129435be2720ae8698e0aa1de260374e8a"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.github/workflows/kas-auto-build.yml",
+      "SPDXID": "SPDXRef-File--.github-workflows-kas-auto-build.yml-BCA65F4579DB4B6424E88E7184147451015AC94C",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "fe842d4d647e3b6b813f8bbc1d8bdcaf80d9363fe185b4da3ba8cd4da7115383"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "bca65f4579db4b6424e88e7184147451015ac94c"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./test/test_static_config.py",
+      "SPDXID": "SPDXRef-File--test-test-static-config.py-47FF9981FC9B1718C94E13C3E0E5C15DAA0F6549",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "2944ef3be144e8fed7b512fb6c16f03276654df10946f1b294638ac1152f015c"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "47ff9981fc9b1718c94e13c3e0e5c15daa0f6549"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./test/fixture/calibration_analyze.csel",
+      "SPDXID": "SPDXRef-File--test-fixture-calibration-analyze.csel-3329494445A06C421C84B682F60CF28FEF665F5A",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "47eca3b1c53732e03da56ead7880918a283b59ded6236e4a70224dfb42b2d2cd"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "3329494445a06c421c84b682f60cf28fef665f5a"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./kas-build.yml",
+      "SPDXID": "SPDXRef-File--kas-build.yml-B429194A86D4E5BBFD6713A8BF982A09643196A8",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "8709ca06ad8d6d1f27bf23ca3c533c5a162deb5797920b0e79f61434c6da5a5f"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b429194a86d4e5bbfd6713a8bf982a09643196a8"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./prj.conf",
+      "SPDXID": "SPDXRef-File--prj.conf-06A4F39165FD4E56763CA2FCA64B0EF8954C3CE1",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "4246383542c78173c37081b565b7b07a70757ee50198882dd7445c5fddd3dda4"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "06a4f39165fd4e56763ca2fca64b0ef8954c3ce1"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./documentation/conf.py",
+      "SPDXID": "SPDXRef-File--documentation-conf.py-032B36C380275C8ECE8607D9A1D01E7196A799A9",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "e556feb5583ce2db454b30cb33eb7b6c78021a7c4699717f80850cad63165935"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "032b36c380275c8ece8607d9a1d01e7196a799a9"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./documentation/manual/message_protocol.rst",
+      "SPDXID": "SPDXRef-File--documentation-manual-message-protocol.rst-81BF4DD1113F1BFA114B3C24F487C25EC1DE411A",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "5d63154462814142b7f0f292a5da559ebee4389ce73c82119b8d83fd87faba4c"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "81bf4dd1113f1bfa114b3c24f487c25ec1de411a"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./documentation/images/cam_timings.svg",
+      "SPDXID": "SPDXRef-File--documentation-images-cam-timings.svg-212AEA7CE6959DCD5A9AD861693FA86FDA5862B0",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "60c1251cb5daab63987a55f04c9dd35265b0284d597645438e2a4d39aeda5551"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "212aea7ce6959dcd5a9ad861693fa86fda5862b0"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/demos/IntegrationDoc.md",
+      "SPDXID": "SPDXRef-File--docs-demos-IntegrationDoc.md-9253A9105C5600331DA5F412467EBC68670DB799",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "9a6ac7b9700a6b47f44f6f8c2bd7ba8f5b6bade98dceddec9a2b5ba2e2e37524"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "9253a9105c5600331da5f412467ebc68670db799"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/strictdoc/03_tsc_lite.sdoc",
+      "SPDXID": "SPDXRef-File--docs-strictdoc-03-tsc-lite.sdoc-0A6007ADC4AD1CD912F4A51887D411536CA3AAE6",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "50eadff65ff82dd1a03d4eb4a87f9c7d68a19424a321ac1b3d94b08e77fe4c3f"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "0a6007adc4ad1cd912f4a51887d411536ca3aae6"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/strictdoc/07_test_specs.sdoc",
+      "SPDXID": "SPDXRef-File--docs-strictdoc-07-test-specs.sdoc-801B381EADC023B6227BFA3A4E0CCAD2C9C9DCC0",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "9414c5054cabe20e81255c154b08245753ce3b0f7799e5b8c0df810f88be6f7b"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "801b381eadc023b6227bfa3a4e0ccad2c9c9dcc0"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/strictdoc/evidence/EVID-002-out-of-order-event-detection.txt",
+      "SPDXID": "SPDXRef-File--docs-strictdoc-evidence-EVID-002-out-of-order-event-detection.txt-F6D6BB3A3BD6BC9CC5495DBB440866A482517F37",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "f2281f8508ef75393bb787ed86c6f9d06ba75bceae2fac20927283000b46588d"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "f6d6bb3a3bd6bc9cc5495dbb440866a482517f37"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.gitattributes",
+      "SPDXID": "SPDXRef-File--.gitattributes-B6143C97D3D1DD843B6D533BD4847C1A81E2D756",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "bfe2e7093f352205764534b2fc590dd92addf7e46dc6e29e66e6701706a9e581"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b6143c97d3d1dd843b6d533bd4847c1a81e2d756"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./Kconfig",
+      "SPDXID": "SPDXRef-File--Kconfig-F465C8DC8C1F3062054BE5523F07B9EC3E6851D8",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "c18cd5a072d322e940500a1ce579469675d6bf70e0928fac971649933a328671"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "f465c8dc8c1f3062054be5523f07b9ec3e6851d8"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./documentation/index.rst",
+      "SPDXID": "SPDXRef-File--documentation-index.rst-60ED03295AA86DCA8A81B1FC8A03973B0D59ED09",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "1244b1f142c042ff74a0a1e3bb622f6047d4fd1d50f4518588abeb7fe2b6d85e"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "60ed03295aa86dca8a81b1fc8a03973b0d59ed09"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./documentation/manual/file_csd.rst",
+      "SPDXID": "SPDXRef-File--documentation-manual-file-csd.rst-BEF0A366BD190B3C9987FE6596FCCFBB3879EB3B",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "a7cb63218cbf1b993631c8ae9695caeaafe36c9f0704249116c20b42cd45d85f"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "bef0a366bd190b3c9987fe6596fccfbb3879eb3b"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./documentation/images/event_interval.svg",
+      "SPDXID": "SPDXRef-File--documentation-images-event-interval.svg-121EC6E3C791FDF92DF651A84CAC062D0C328466",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "4ecce26880fbe70b0fed4f0ded997c30a1d7ff946c68687fc060bd087082e1d5"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "121ec6e3c791fdf92df651a84cac062d0c328466"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/demos/cicd.png",
+      "SPDXID": "SPDXRef-File--docs-demos-cicd.png-1CC22BC2C252E9668F878003ACD10A0204CCA471",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "745daad2318ca57eaedb26ae417f0704be3d93e826634638e2f8d00ef0adc435"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "1cc22bc2c252e9668f878003acd10a0204cca471"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/strictdoc/04_ssr_cam.sdoc",
+      "SPDXID": "SPDXRef-File--docs-strictdoc-04-ssr-cam.sdoc-EE9983D01C412C9F73925C799C391C2920003330",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "aaa1cd0c7a85b3faf4bbd2cf4d37476d29a0e3a04e4da3e4de38651991dd9d84"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "ee9983d01c412c9f73925c799c391c2920003330"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/strictdoc/05_swa_cam.sdoc",
+      "SPDXID": "SPDXRef-File--docs-strictdoc-05-swa-cam.sdoc-9F15A3AA7EEB2F99FD3A031DB26DA9C2D89E4870",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "41f52f4ce8e5d35a7014d7f1c27a32230ed92be70d61fb79c50b36671d7791f2"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "9f15a3aa7eeb2f99fd3a031db26da9c2d89e4870"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/strictdoc/evidence/EVID-006-csc-validation-and-conversion.txt",
+      "SPDXID": "SPDXRef-File--docs-strictdoc-evidence-EVID-006-csc-validation-and-conversion.txt-D554A42A6064AAEAEC0441B452440D93314A97CF",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "762ddb1f6cc1365b3b2a3f1b44cedda7cf8c145ca857de43c065b978ca06ebfd"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "d554a42a6064aaeaec0441b452440d93314a97cf"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.gitmodules",
+      "SPDXID": "SPDXRef-File--.gitmodules-2D3388FE54BDC635318EE07D60AD92DC4FAFCDA4",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "f4170934898bc41c156c3122f88cb1945b250c14e8f67788384baa2a58391687"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "2d3388fe54bdc635318ee07d60ad92dc4fafcda4"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./documentation/getting_started.rst",
+      "SPDXID": "SPDXRef-File--documentation-getting-started.rst-65E3C81C64BFD1C2E85F65DCBE06B47D76BB987C",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "4cebeb5de24398fde4460c4f3f597391dc9e22041a361ec1a994ca6a76628ac6"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "65e3c81c64bfd1c2e85f65dcbe06b47d76bb987c"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./documentation/development/coding_style.rst",
+      "SPDXID": "SPDXRef-File--documentation-development-coding-style.rst-695E8BCBC4E82D3C403A30B9C2F409DFB8BB6FA3",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "1ca26c79dcd52cb3bf06157b0127b695301742c71363e95266ae40a2c27797a9"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "695e8bcbc4e82d3c403a30b9c2f409dfb8bb6fa3"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./documentation/manual/libcam_api.rst",
+      "SPDXID": "SPDXRef-File--documentation-manual-libcam-api.rst-02E25925E274224DB87DBA00762F95D86D3F72F5",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "9b6e07167975f464b2c81fd452a5f53e0db78f1ffce654edbcf0dd061154560e"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "02e25925e274224db87dba00762f95d86d3f72f5"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/.DS_Store",
+      "SPDXID": "SPDXRef-File--docs-.DS-Store-3FDBB98C715247247D3549E4E622E97F29C6E369",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "7387851e32fe2162fb1e758351eebe2cd3b836087859300147f71ce46ce82617"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "3fdbb98c715247247d3549e4e622e97f29c6e369"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/strictdoc/00_item_definition.sdoc",
+      "SPDXID": "SPDXRef-File--docs-strictdoc-00-item-definition.sdoc-B33028A11A42301C6E384B008EA93DAE78DB29B9",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ce58c5593f3a589acbe7496d8293e152b17e67d5e20b9c78bfbf14eb660f84e3"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b33028a11a42301c6e384b008ea93dae78db29b9"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/strictdoc/strictdoc.toml",
+      "SPDXID": "SPDXRef-File--docs-strictdoc-strictdoc.toml-57DD715261F13F14197A237D5C44C21C35268147",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "49978701fa0eb1bf0a4ae59777ca97b8d3c90eeb4717276949e0ccb8470123eb"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "57dd715261f13f14197a237d5c44c21c35268147"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/strictdoc/evidence/EVID-003-sequence-mismatch-fault.txt",
+      "SPDXID": "SPDXRef-File--docs-strictdoc-evidence-EVID-003-sequence-mismatch-fault.txt-7ACA608B64600100B9F5F53AB750912C0D34CC58",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "faae9818313fe439f84e1d97d812ee16c11cada5ae82bc7c631affc4ebecca14"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "7aca608b64600100b9f5f53ab750912c0d34cc58"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/strictdoc/evidence/EVID-005-event-before-start-fault.txt",
+      "SPDXID": "SPDXRef-File--docs-strictdoc-evidence-EVID-005-event-before-start-fault.txt-F738A8DB8ECFF9C604D31E2A783B2DFC48494F54",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "e95af6f3418a57aef8fbddfaaa13463600c4a28b2f10be8efcea6a7231fefaed"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "f738a8db8ecff9c604d31e2a783b2dfc48494f54"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.github/dependabot.yml",
+      "SPDXID": "SPDXRef-File--.github-dependabot.yml-3D2B68A042CA883BE6F12D33A24FABD3931FBC73",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "aad36a8d821d1705019256652894553150bac03dbaa95a00f4459fbc2c1c13b2"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "3d2b68a042ca883be6f12d33a24fabd3931fbc73"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.github/workflows/code-coverage.yaml",
+      "SPDXID": "SPDXRef-File--.github-workflows-code-coverage.yaml-96397A8E74EE740B15453C4EDF094515B5BF8CBD",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "d085056c61d53760ab5fa23eecd411e77f2ddc0f86f7d208903a47f7b5c941f4"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "96397a8e74ee740b15453c4edf094515b5bf8cbd"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.github/workflows/build-cam-app.yaml",
+      "SPDXID": "SPDXRef-File--.github-workflows-build-cam-app.yaml-45AD4A5CE3AA967FBCBFE79CF8ACCFBE1031020B",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "846a236683ac75b515d640ed4a88d6cf0879e2b08da1c8a963ea45c808568f5f"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "45ad4a5ce3aa967fbcbfe79cf8accfbe1031020b"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./test/fixture/config_deploy_invalid.csd",
+      "SPDXID": "SPDXRef-File--test-fixture-config-deploy-invalid.csd-3329494445A06C421C84B682F60CF28FEF665F5A",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "47eca3b1c53732e03da56ead7880918a283b59ded6236e4a70224dfb42b2d2cd"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "3329494445a06c421c84b682f60cf28fef665f5a"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/pyproject.toml",
+      "SPDXID": "SPDXRef-File--cam-tool-pyproject.toml-69538DF8B7CA45392165C8DE6931B98B5451BEDB",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "9fcce9b33f719d5a9226717fc973250662fffbf9275b54c329d408da68134267"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "69538df8b7ca45392165c8de6931b98b5451bedb"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.DS_Store",
+      "SPDXID": "SPDXRef-File--.DS-Store-4B84BEED4F4ACC6F98DCAF193C0A2BB05F533D9A",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "6558814771674110a74a7012daa0414b3b7c25d1541405d843c5a4d1409829d0"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "4b84beed4f4acc6f98dcaf193c0a2bb05f533d9a"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./documentation/doxyfile.in",
+      "SPDXID": "SPDXRef-File--documentation-doxyfile.in-53C725FA349593DE2980031FF464EB191702DB64",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "9943f9a3e672c835e923e5de6abeeadad4fd4bb310870379f5fce1c366179677"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "53c725fa349593de2980031ff464eb191702db64"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./documentation/development/validation.rst",
+      "SPDXID": "SPDXRef-File--documentation-development-validation.rst-8F4D47C8A2CE2C2A31B1463FD36C344533BA1426",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "da4835c98d121ba4dec463d0fff9b1787b9cd2c22dc50a0d68575153e010ef95"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "8f4d47c8a2ce2c2a31b1463fd36c344533ba1426"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./documentation/manual/index.rst",
+      "SPDXID": "SPDXRef-File--documentation-manual-index.rst-6000F7F3027086ED04B6D2CE5B649AE2A0CE8DDE",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "fe64b83ed1ab948f45fe8a939329f73499de37c89b8be5abc443f87429f289fb"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6000f7f3027086ed04b6d2ce5b649ae2a0ce8dde"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/demos/project-gearshift-demo-scenario-copilot.md",
+      "SPDXID": "SPDXRef-File--docs-demos-project-gearshift-demo-scenario-copilot.md-DADE9124CCA3B182500FEDF4E21045D3F2D37092",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "71b3b21c6c249af14fee869e7813f05783164976e3637aca8c395fcd1d6d1e98"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "dade9124cca3b182500fedf4e21045d3f2d37092"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/strictdoc/08_evidence_log.sdoc",
+      "SPDXID": "SPDXRef-File--docs-strictdoc-08-evidence-log.sdoc-C7EAE589EDA66EF750173C9EE3219B1351A89694",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "5f8bdf7fa0bb65dd97095c2e78534cf099580d89f0a53bd6a7c615cad1fe6e62"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c7eae589eda66ef750173c9ee3219b1351a89694"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/strictdoc/EXPORT_INSTRUCTIONS.md",
+      "SPDXID": "SPDXRef-File--docs-strictdoc-EXPORT-INSTRUCTIONS.md-2501658D15C120630C7832F07E05942BD02F9A92",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "b044f6e7f2e8d80c24803ce33b3d00e0adff4313239b95d203c1008da9703f72"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "2501658d15c120630c7832f07e05942bd02f9a92"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/strictdoc/evidence/EVID-004-start-to-first-event-timeout.txt",
+      "SPDXID": "SPDXRef-File--docs-strictdoc-evidence-EVID-004-start-to-first-event-timeout.txt-50BDFB19E32CA59800505F1C60530B506A4F5264",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ec2f511f8582ad42adf17c9633f8d676a75a5feea54b0f6d464ff483f4d4ae82"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "50bdfb19e32ca59800505f1c60530b506a4f5264"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/strictdoc/evidence/EVID-012-ci-sbom-artifact.txt",
+      "SPDXID": "SPDXRef-File--docs-strictdoc-evidence-EVID-012-ci-sbom-artifact.txt-BE4E7E0B040AE85FA02914991445D29B27537383",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "47161062db164faa81df533b7820580877b313e0820ca131a44a9b0120d72096"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "be4e7e0b040ae85fa02914991445d29b27537383"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.github/workflows/super-linter.yaml",
+      "SPDXID": "SPDXRef-File--.github-workflows-super-linter.yaml-A4D9459C3877B00E6FA98054D10250ADA592E960",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "384d18b7254045c7b94e48873151c9b205e231245bb8c6c2a7e6200da443ea68"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "a4d9459c3877b00e6fa98054d10250ada592e960"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.github/workflows/safety-docs.yml",
+      "SPDXID": "SPDXRef-File--.github-workflows-safety-docs.yml-02CE9D355E7785FF72EE0E8414A6DB926C0B189B",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "b71c84fb4d921422dcfe3ef53798039269eb90cba4802d8a7ce1c3dac39b88cb"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "02ce9d355e7785ff72ee0e8414a6db926c0b189b"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.github/workflows/correlium.yaml",
+      "SPDXID": "SPDXRef-File--.github-workflows-correlium.yaml-E233632E89F7F03755E9D2F8A4B16317E65B9AAE",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "7735c260ff3605fa929d0ac5e48ea06f19c31e8594b17c0b294a1decd2890899"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "e233632e89f7f03755e9d2f8a4b16317e65b9aae"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./test/fixture/99085ddc-bc10-11ed-9a44-7ef9696e0000.csd",
+      "SPDXID": "SPDXRef-File--test-fixture-99085ddc-bc10-11ed-9a44-7ef9696e0000.csd-8CAD6A0C5B6F171CF8F0AF0BE03FB2070C8CD7C0",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "d40ace2ec09d58fd5073be91fc74ec50a330a6d451110b606b87f2cf817c6970"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "8cad6a0c5b6f171cf8f0af0be03fb2070c8cd7c0"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./Dangerfile",
+      "SPDXID": "SPDXRef-File--Dangerfile-0FF0B87CC10146DEA17C795E40C60B7A2B33AEF6",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "4e90bc4b377f6dc175867d01e226774ec84fe7664dc2040139af130561b7c4d4"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "0ff0b87cc10146dea17c795e40c60b7a2b33aef6"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./documentation/CMakeLists.txt",
+      "SPDXID": "SPDXRef-File--documentation-CMakeLists.txt-2B74A3223044E50C4AAC16EC4AA4DBCA34EED324",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "d2260d1ff1cee4bea7c5b8933b02f010428bb88e0e78e0a33535d20ffd4e3ad0"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "2b74a3223044e50c4aac16ec4aa4dbca34eed324"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./documentation/development/index.rst",
+      "SPDXID": "SPDXRef-File--documentation-development-index.rst-F31BE237B430E33F3346DAE9C5E7D8CB6A5C608D",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "5de179e3d0a750686a34f0fa45cbe49b439e90f05e3808889005313421460a4c"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "f31be237b430e33f3346dae9c5e7d8cb6a5c608d"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./documentation/images/cam_components.svg",
+      "SPDXID": "SPDXRef-File--documentation-images-cam-components.svg-48EB74708336D066955B4810FCF33C5E8D356B43",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "4eafcfa6458739814d412dd819566d5e3b741fa2bca4b5f918e62a583094d0fa"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "48eb74708336d066955b4810fcf33c5e8d356b43"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/demos/README.md",
+      "SPDXID": "SPDXRef-File--docs-demos-README.md-6C5F2B7281974392451115F37581C6F9A4FDFEAD",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "0db1b1e858c0dcc08fc04debaa8100fc9f061115a292d7e85f56acbcb9c92d5d"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6c5f2b7281974392451115f37581c6f9a4fdfead"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/strictdoc/README.md",
+      "SPDXID": "SPDXRef-File--docs-strictdoc-README.md-29F540525AF57E8F3C885362231B0F5D98FC42FD",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "beafa75d380b164edc2ce391c4449e22e9def35b94cbdf1679ce207119629d5a"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "29f540525af57e8f3c885362231b0f5d98fc42fd"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/strictdoc/09_trace_matrix.sdoc",
+      "SPDXID": "SPDXRef-File--docs-strictdoc-09-trace-matrix.sdoc-B386FDCE09A2F51191FC15DDD0DFA1B4A330F1D0",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ef59a9012b902c4e17df494a14f65e95c26a4554480c3d3351fe41501ec16bc4"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b386fdce09a2f51191fc15ddd0dfa1b4a330f1d0"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/strictdoc/evidence/EVID-011-protocol-header-handler-validation.txt",
+      "SPDXID": "SPDXRef-File--docs-strictdoc-evidence-EVID-011-protocol-header-handler-validation.txt-52CDDC675EC716E1D497915CB01CE0026506D515",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "0629c2bb09315f6109c09318586711163a497564f44fd844a35fec6e3d5bc86f"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "52cddc675ec716e1d497915cb01ce0026506d515"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/strictdoc/evidence/EVID-009-csel-generation-and-analysis.txt",
+      "SPDXID": "SPDXRef-File--docs-strictdoc-evidence-EVID-009-csel-generation-and-analysis.txt-7B73F07346B04D25D4A18C4B1B780A0876D93492",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "3e5eb5676fba7911ad5b23796ae67112b30dba0216cacdf14dcc0957cb48036e"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "7b73f07346b04d25d4a18c4b1b780a0876d93492"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.github/workflows/mainSBOMgen.yml",
+      "SPDXID": "SPDXRef-File--.github-workflows-mainSBOMgen.yml-55DD4509FCC09AE090C0256FC0E829B8631DEC5F",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "4e0ce05be18b888b5e9b95a119364f38a1633113f30b0f92abda1694ddd7a89d"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "55dd4509fcc09ae090c0256fc0e829b8631dec5f"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.github/workflows/sbom_exper2.yml",
+      "SPDXID": "SPDXRef-File--.github-workflows-sbom-exper2.yml-E3562936495B7045E97B5BE23FFCC104EB1C9484",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "32fb627160ef55960fcbd808596587a53ecc3a4af2fd7eee4a33b3820cc1c398"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "e3562936495b7045e97b5be23ffcc104eb1c9484"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./test/test_calibration.py",
+      "SPDXID": "SPDXRef-File--test-test-calibration.py-C89FCFA1CE881D2D7D1263C88C3A962D2DAF91D1",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "8f1a2edb3e95ddcbfef1c118696e363c0a469c207d3676de79b0296fb6141fd2"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c89fcfa1ce881d2d7d1263c88c3a962d2daf91d1"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./test/fixture/config_deploy_valid.csd",
+      "SPDXID": "SPDXRef-File--test-fixture-config-deploy-valid.csd-83CC858D76EC1456512DFFA407E8893E3B3997FF",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "da6c171e6eb22e031686bc5b0c6a4335e50103e84c9e52d38349e1ed316df39c"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "83cc858d76ec1456512dffa407e8893e3b3997ff"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/cam_tool/cam_csd.py",
+      "SPDXID": "SPDXRef-File--cam-tool-cam-tool-cam-csd.py-6227BB362E49D0D96E6610527B3A5299CE7F4766",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "24bdd1ea7596e6bd3abd9f5262aa103d4b6b4d03c357e118820d348a005fb6ff"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6227bb362e49d0d96e6610527b3a5299ce7f4766"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/cam_tool/cam_deploy.py",
+      "SPDXID": "SPDXRef-File--cam-tool-cam-tool-cam-deploy.py-5098F7AA4441CBEB1D52C9F017999C43C6D055A8",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "e702cc440e169b917aa04db00d890296ab3eb955c208a5c2b4ce71e8aedb1c5d"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "5098f7aa4441cbeb1d52c9f017999c43c6d055a8"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/invalid_timeout.csc.yml",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-invalid-timeout.csc.yml-F29793EED18438DC1BFD6B3D3356FAA3B951657B",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "c35c9a81139630b41b98850a83d42ba54b6bd3023b724d5b883d2cdec55747ff"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "f29793eed18438dc1bfd6b3d3356faa3b951657b"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/no_version.csc.yml",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-no-version.csc.yml-64AF7B974DCB6CD16359FD34F6DA3A7B598FA0D2",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "08abfe1b763b57ed7a2af893e5236c4ada96c84d12f7f3d91add7e32be291ab8"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "64af7b974dcb6cd16359fd34f6da3a7b598fa0d2"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/invalid_version.csc.yml",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-invalid-version.csc.yml-08BA3ADE3C14F15129F6165C47C429BE76674946",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "697a2a5b5e38f9fe9ce6368a46563bbb4d455c87f66ae6f98c0b63b4d98aea2b"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "08ba3ade3c14f15129f6165c47c429be76674946"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/file_size_overflow.csd",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-file-size-overflow.csd-70F9465FE4A5A7C41EACF00DAC3B9F61002C519C",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "e52073faf95c7e8ea2e92c544ac70ad87bae01ee22d28daacaa50e428af1caa5"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "70f9465fe4a5a7c41eacf00dac3b9f61002c519c"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/unexpected_status_type.msg_rcv",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-unexpected-status-type.msg-rcv-C4E1A68A47741430037C51F1CADD5E2F80DEBBE3",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "bd1ef47cd7456c52c43c92ee70f385e5c286c10922aa47be39af3f30c6bd1b04"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c4e1a68a47741430037c51f1cadd5e2f80debbe3"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./libcam/test/src/test_suite.c",
+      "SPDXID": "SPDXRef-File--libcam-test-src-test-suite.c-A1AF64B2AAEF31D7E5E03BC1A17A7EF16465A838",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "df10e3e23f7a8cedbd10e54a36f3e6eda3986e8bc816810456a20624b66d274b"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "a1af64b2aaef31d7e5e03bc1a17a7ef16465a838"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-uuid/test/CMakeLists.txt",
+      "SPDXID": "SPDXRef-File--cam-uuid-test-CMakeLists.txt-73529D565EAB077BE2941022E5A881541529D7F0",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "801497af106e5afff6a52a603458567c686dab19abad47bd631f678887b14d5f"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "73529d565eab077be2941022e5a881541529d7f0"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/config.worktree",
+      "SPDXID": "SPDXRef-File--.git-config.worktree-CA859A5B32728E6B456D4E5011D9011BB638AC1C",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "443a5f645c23c3d0c0aa09f634b2ad111d46ef61946b598a2fb311678ab47454"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "ca859a5b32728e6b456d4e5011d9011bb638ac1c"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/objects/pack/pack-dfc8042bd133851dae79f320666964927acd23d6.rev",
+      "SPDXID": "SPDXRef-File--.git-objects-pack-pack-dfc8042bd133851dae79f320666964927acd23d6.rev-ECEAA6B4884DFD9AA92D685139B6DE50C315A24A",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "f090666ee320ce0d2d2ca1b627c251e1b861088a801c69afdb1a008afcdda062"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "eceaa6b4884dfd9aa92d685139b6de50c315a24a"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/hooks/pre-applypatch.sample",
+      "SPDXID": "SPDXRef-File--.git-hooks-pre-applypatch.sample-F208287C1A92525DE9F5462E905A9D31DE1E2D75",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "e15c5b469ea3e0a695bea6f2c82bcf8e62821074939ddd85b77e0007ff165475"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "f208287c1a92525de9f5462e905a9d31de1e2d75"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/hooks/pre-rebase.sample",
+      "SPDXID": "SPDXRef-File--.git-hooks-pre-rebase.sample-288EFDC0027DB4CFD8B7C47C4AEDDBA09B6DED12",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "4febce867790052338076f4e66cc47efb14879d18097d1d61c8261859eaaa7b3"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "288efdc0027db4cfd8b7c47c4aeddba09b6ded12"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/common/cam_message.h",
+      "SPDXID": "SPDXRef-File--cam-service-common-cam-message.h-5A3730C811AD621A212740FD29F45B63EA8C64AD",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "27570bdd8c3c9035d2f33cae0eb29429b84be93f5c623e05f69455afe68ec94d"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "5a3730c811ad621a212740fd29f45b63ea8c64ad"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/test/src/posix_call_utils.h",
+      "SPDXID": "SPDXRef-File--cam-service-test-src-posix-call-utils.h-5A708BD5310DBEECE6A6080441282457718E7B05",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "8c831cac017b2e08393e4012ca77bee67d2f04c45da5f94af08104a2083c631f"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "5a708bd5310dbeece6a6080441282457718e7b05"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/test/fixture/84085ddc-bc10-11ed-9a44-7ef9696e9dd4.csd",
+      "SPDXID": "SPDXRef-File--cam-service-test-fixture-84085ddc-bc10-11ed-9a44-7ef9696e9dd4.csd-93CEBCFF20A0D6BD76387C9B31399335CA1753CF",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "95b67b06290ed72b4d8990e6b4b5bd4ae2a34da0f60ac26db0a697c009906264"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "93cebcff20a0d6bd76387c9b31399335ca1753cf"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/src/cam_config.c",
+      "SPDXID": "SPDXRef-File--cam-service-src-cam-config.c-A33EF64845B1C4765FAF99DB96CB96A4CCA9DD2E",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ae12d337104cd30e7a85a566a49b844dcef44118b83ccd59e64cba574a5da36c"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "a33ef64845b1c4765faf99db96cb96a4cca9dd2e"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/src/cam_socket.h",
+      "SPDXID": "SPDXRef-File--cam-service-src-cam-socket.h-DB7379FF8E36074013239786061C8128A9F12175",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "bffb37511d7b3e814fabaa1e58a9e561fd28b5220e1f5dfee38c34594f072c37"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "db7379ff8e36074013239786061c8128a9f12175"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-app-example/cam-data/stream3.csc.yml",
+      "SPDXID": "SPDXRef-File--cam-app-example-cam-data-stream3.csc.yml-CAF7B6B3E42354802A33581855DD5EBE8B0FF855",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "d69617a72edd0050b0288b4b8a6004bab44f9ec271d298e9265318f5b641150c"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "caf7b6b3e42354802a33581855dd5ebe8b0ff855"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/cam_tool/cam_analyze.py",
+      "SPDXID": "SPDXRef-File--cam-tool-cam-tool-cam-analyze.py-B7F2804A15B69FE382C7D56ED940C4691B7846BB",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "be02db66388fdfbd7dea6cc9936ffa190efa0bc6f668ec3e9aaceebe99b099a0"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b7f2804a15b69fe382c7d56ed940c4691b7846bb"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/test_cam_csd.py",
+      "SPDXID": "SPDXRef-File--cam-tool-test-test-cam-csd.py-A8EF645A845E0671A682E6EAA816F20728914CC4",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "a703284cfbd7cec6fb5c3183b998320b592121add204774050710dd65b485784"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "a8ef645a845e0671a682e6eaa816f20728914cc4"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/inconsistent_uuid.msg_rcv",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-inconsistent-uuid.msg-rcv-F51A3E3AA4A405B281EE23C4A5DA4BACBE64C8D5",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ef0b5a8a0733361bb5909947ce4eea9df6a8b90c1d57385d3728e674be1c04c0"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "f51a3e3aa4a405b281ee23c4a5da4bacbe64c8d5"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/invalid_entry_type.csel",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-invalid-entry-type.csel-47CEA57F0303B2C20AC64884262A907A1B832263",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "7b9094fcf38d313a36c1e63224da752029ece50bd14031067f676468747553af"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "47cea57f0303b2c20ac64884262a907a1b832263"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/invalid_command_id.msg_rcv",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-invalid-command-id.msg-rcv-6892044A8100A5425A569EB2127A53914DBED544",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ca91fbc8efae53bb1f88a3d0d8ed983f35dfc65f6f4210374491049c7c6814f6"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6892044a8100a5425a569eb2127a53914dbed544"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/no_padding_bytes.csel",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-no-padding-bytes.csel-6022672C7971BE526F9CBB4B7FD4E6F3467DCF04",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "caab470eb1d01a2df8d1dc0fc4e4ead9b4a93c13c79ba408464970d5c20bb2e2"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6022672c7971be526f9cbb4b7fd4e6f3467dcf04"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/no_meta.csc.yml",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-no-meta.csc.yml-51A03E2DD226DE200EAB9B90FD5D85A9CB0BC05A",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ce3fdb1245f71985aa05d5507f28ce74e2e2b5a5d006a28791074268fd5c0478"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "51a03e2dd226de200eab9b90fd5d85a9cb0bc05a"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./libcam/test/src/test_suite.h",
+      "SPDXID": "SPDXRef-File--libcam-test-src-test-suite.h-30E60F13DCD57065C8F3206914794786E9AEBFFF",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "c5572b8e6f334f12975c382b084a76d5b9ec99248a60a8ba426dcf073a51007c"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "30e60f13dcd57065c8f3206914794786e9aebfff"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-uuid/test/src/test_suite.c",
+      "SPDXID": "SPDXRef-File--cam-uuid-test-src-test-suite.c-A29C11054F5F209D10963CEDB0018D9D561AE899",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "005fb283d680fa68aebfba395d97ac6d4b00d2e3cafb02586da177d3a765dfa4"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "a29c11054f5f209d10963cedb0018d9d561ae899"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/shallow",
+      "SPDXID": "SPDXRef-File--.git-shallow-51A5D749C236F93BE2E93DFD8D1AA64D4F4069C9",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "0072b03c49123bfce468ef54cbe0aabe0399fcc2fb2a9da3ce27b95694f595bc"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "51a5d749c236f93be2e93dfd8d1aa64d4f4069c9"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/screencast-recordings/TMUX_and_Installation.mp4",
+      "SPDXID": "SPDXRef-File--docs-screencast-recordings-TMUX-and-Installation.mp4-94759FDB0D2B2BDC81A54177857B633B58ECF40A",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "4750f07d685f3f1654588a9a734143bfdf8a7d6ee6f4d40f51d81efe9b6a042f"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "94759fdb0d2b2bdc81a54177857b633b58ecf40a"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.github/workflows/Kronos.yaml",
+      "SPDXID": "SPDXRef-File--.github-workflows-Kronos.yaml-93C30B82E49670E235C9947A73DE21546C57C382",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ea79dd0de1c0ea4261317fc5cf2384259353957f35bef8bccd8bd0bfe5296696"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "93c30b82e49670e235c9947a73de21546c57c382"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.github/workflows/build-reusable_workflow.yaml",
+      "SPDXID": "SPDXRef-File--.github-workflows-build-reusable-workflow.yaml-2B82A21138E22A49A4974C77CC72148502811D37",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "3ac9974b38ce4133a4c81e3f11b226eb8b4160440a7531a954141779fdad3c86"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "2b82a21138e22a49a4974c77cc72148502811d37"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./test/component.py",
+      "SPDXID": "SPDXRef-File--test-component.py-67D5218B42DDBEAA911052EF0F5DB3F98A999C5D",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "69a8c67a66a553a595ca7f267ba0f31d8938cdc450ce598a1b0d59dc037cb4ba"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "67d5218b42ddbeaa911052ef0f5db3f98a999c5d"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./test/fixture/calibration_pack.csc.yml",
+      "SPDXID": "SPDXRef-File--test-fixture-calibration-pack.csc.yml-2E3BED5132B7703A04D82A393AC467EA404A55F5",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "f4cd652b0ab504ab912a015940bb61b0f3446e8b8a2641f0476c959ca122b8d1"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "2e3bed5132b7703a04d82a393ac467ea404a55f5"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/cam_tool/cam_pack.py",
+      "SPDXID": "SPDXRef-File--cam-tool-cam-tool-cam-pack.py-B73CEB94236EB844F3187274186E66BB78742541",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "67ed1f7083c037732f6c978434f74cc23da9c1d97c2a77f8eac34e89de192077"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b73ceb94236eb844f3187274186e66bb78742541"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/test_cam_csel.py",
+      "SPDXID": "SPDXRef-File--cam-tool-test-test-cam-csel.py-7735F74E5A53D0CCF8B020CC6676F0B44C6E0E1F",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "166fb86fdefe504e1e44014d02052cc708465c57e629b2c50476694c93ba8ba6"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "7735f74e5a53d0ccf8b020cc6676f0b44c6e0e1f"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/invalid_mode_name.csc.yml",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-invalid-mode-name.csc.yml-721F11B27E196CFAE16575241E468AD3EDB67EF0",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "b53597120e30cfb8119f4bc549476a4f214e730ff1c129f8eb894ae9550c24f8"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "721f11b27e196cfae16575241e468ad3edb67ef0"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/no_end_entry.csel",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-no-end-entry.csel-42557B34D8D6DF1B31755F521EC2CE886AB9EC07",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ebb172fd749d4734a2da9b887cb72ba2b929d533e4b0566851c03f598776fe84"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "42557b34d8d6df1b31755f521ec2ce886ab9ec07"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/invalid_event_alarm_format.csd",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-invalid-event-alarm-format.csd-9DBB2033B1CB9D7A7BFF6F52902431236248E50A",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "f0b3ee7ad1e961532dda955cc0fb588a39af2ef377d5799e3d950d26198c65e8"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "9dbb2033b1cb9d7a7bff6f52902431236248e50a"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/expected_output.csd",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-expected-output.csd-83CC858D76EC1456512DFFA407E8893E3B3997FF",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "da6c171e6eb22e031686bc5b0c6a4335e50103e84c9e52d38349e1ed316df39c"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "83cc858d76ec1456512dffa407e8893e3b3997ff"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./libcam/include/cam_version.h.in",
+      "SPDXID": "SPDXRef-File--libcam-include-cam-version.h.in-1A3E9FB08FDACEB2EA734ED61ED9A28F7690AFFD",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "566c0ec35a9926bbf821b807c6974ee3769a9a4a9d1d323a38a731dd7b4a29ec"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "1a3e9fb08fdaceb2ea734ed61ed9a28f7690affd"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./libcam/src/cam_csel.h",
+      "SPDXID": "SPDXRef-File--libcam-src-cam-csel.h-63E3FDF626E3EC6B30E49F467EFD152962A448D1",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "535e2d155c16c51a182a1dc59ec55d49674a77892074112792cdb31192217d98"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "63e3fdf626e3ec6b30e49f467efd152962a448d1"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/HEAD",
+      "SPDXID": "SPDXRef-File--.git-HEAD-9F1DF7EEA4156BE8A871C292B549B3325E425AA2",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "28d25bf82af4c0e2b72f50959b2beb859e3e60b9630a5e8c603dad4ddb2b6e80"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "9f1df7eea4156be8a871c292b549b3325e425aa2"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/logs/refs/remotes/origin/main",
+      "SPDXID": "SPDXRef-File--.git-logs-refs-remotes-origin-main-676FF629BF28BBA22AF6BDB2ACC069C3188AA2CB",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "d33ee8b585a1199b6b3fecaf200a699a0cbc2c892259d88b4e9c8269e75337d6"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "676ff629bf28bba22af6bdb2acc069c3188aa2cb"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/hooks/post-commit",
+      "SPDXID": "SPDXRef-File--.git-hooks-post-commit-90E83D48D2E5C47663F21FF5043E31FE56C12278",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "f3eb4d1f62924c09d481a0563a84b158c66eb2feb3431cfdb3e6760aab4d661d"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "90e83d48d2e5c47663f21ff5043e31fe56c12278"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/hooks/prepare-commit-msg.sample",
+      "SPDXID": "SPDXRef-File--.git-hooks-prepare-commit-msg.sample-2584806BA147152AE005CB675AA4F01D5D068456",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "e9ddcaa4189fddd25ed97fc8c789eca7b6ca16390b2392ae3276f0c8e1aa4619"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "2584806ba147152ae005cb675aa4f01d5d068456"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/refs/remotes/origin/main",
+      "SPDXID": "SPDXRef-File--.git-refs-remotes-origin-main-51A5D749C236F93BE2E93DFD8D1AA64D4F4069C9",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "0072b03c49123bfce468ef54cbe0aabe0399fcc2fb2a9da3ce27b95694f595bc"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "51a5d749c236f93be2e93dfd8d1aa64d4f4069c9"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/test/src/test_cam_log.c",
+      "SPDXID": "SPDXRef-File--cam-service-test-src-test-cam-log.c-B3FD6CBC0A39BA5AADAE5814E341E525EE6F1ED6",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "e233b2a18ab2c79e5399a97804070b808187e595497fe7eec15ed501b24d80a3"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b3fd6cbc0a39ba5aadae5814e341e525ee6f1ed6"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/test/fixture/84085ddc-bc10-11ed-9a44-7ef9696e9dd5.csd",
+      "SPDXID": "SPDXRef-File--cam-service-test-fixture-84085ddc-bc10-11ed-9a44-7ef9696e9dd5.csd-062A9CDAE020D704F8D4FFE9493B52983CFD23A9",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "2990708e97a5f73078aa65e6691df1efa4bd74a80984357e7c529d2b8ef73f54"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "062a9cdae020d704f8d4ffe9493b52983cfd23a9"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/src/cam_service.h",
+      "SPDXID": "SPDXRef-File--cam-service-src-cam-service.h-593180CC11784FDA23FDC1B1D87169C53FAD4DFE",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "1793e696e522c2fe8ceee22621f31be02867912dc0356c287319c31b567969d6"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "593180cc11784fda23fdc1b1d87169c53fad4dfe"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/src/cam_csd.h",
+      "SPDXID": "SPDXRef-File--cam-service-src-cam-csd.h-0EA0E9DCC515C3EB174BD53BBA5850C41E15161A",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "b8ee393927bc9b86e91af7322f09dcc05900cd55d677006264d0483d84db33fa"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "0ea0e9dcc515c3eb174bd53bba5850c41e15161a"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./Dockerfiles/README.md",
+      "SPDXID": "SPDXRef-File--Dockerfiles-README.md-BBB57ECB6744DCEBB9FF2ED57E4517F1A25449E6",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "69f000a860b9f176ab590c146aa57cae6744a179de633065b1ba90f4a6763bad"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "bbb57ecb6744dcebb9ff2ed57e4517f1a25449e6"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-app-example/cam-data/84085ddc-bc10-11ed-9a44-7ef9696e0000.csd",
+      "SPDXID": "SPDXRef-File--cam-app-example-cam-data-84085ddc-bc10-11ed-9a44-7ef9696e0000.csd-01653994DA51EE6149B9B5B5968EBD43B1D910D7",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "44fa17831d5ff71367faa92b8be948d8ba584fe299e3720a0593c2fc74a6231c"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "01653994da51ee6149b9b5b5968ebd43b1d910d7"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-app-example/src/cmdline.h",
+      "SPDXID": "SPDXRef-File--cam-app-example-src-cmdline.h-5CD15E491354536F4B240848DE00DCD5437330A4",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "1e5b4b0f23e9a74c4e8a244e413663e12a69c8c2d1faeb199b1931bb67740111"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "5cd15e491354536f4b240848de00dcd5437330a4"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/screencast-recordings/FVP_Setup_and_terminals_and_commands.mp4",
+      "SPDXID": "SPDXRef-File--docs-screencast-recordings-FVP-Setup-and-terminals-and-commands.mp4-ECA6CB1590899BE0885E03BE85B36B6D8106B4B3",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "79ab4927529078106ffc5ccdf0e808cfd66c3f990ad83b38906043fb4e68c326"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "eca6cb1590899be0885e03be85b36b6d8106b4b3"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.github/workflows/generate_sbom.yml",
+      "SPDXID": "SPDXRef-File--.github-workflows-generate-sbom.yml-F3C517A8812682C0A291C44B79135676D4074D16",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "67db76d2b10d3b26b0a5d5a980f161399a260dac60688b516bb96fabb6bc3760"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "f3c517a8812682c0a291c44b79135676d4074d16"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.github/workflows/repo-sync.yml",
+      "SPDXID": "SPDXRef-File--.github-workflows-repo-sync.yml-997A90A371BB51F06A898A45B9DFD7243517875E",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "e73d941e74a2959d3848f8dde33b7d093136be9733a53a8d00536f2729138b1b"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "997a90a371bb51f06a898a45b9dfd7243517875e"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./test/test_config_deploy.py",
+      "SPDXID": "SPDXRef-File--test-test-config-deploy.py-E9D3FEF98F9501198DCB644A49E68B2323846E22",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "f78defc67fcf02596616cbd259c7bc0e134513b6d96d73d576c676cd7edcf6f5"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "e9d3fef98f9501198dcb644a49e68b2323846e22"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./test/fixture/99085ddc-bc10-11ed-9a44-7ef9696e0000.csc.yml",
+      "SPDXID": "SPDXRef-File--test-fixture-99085ddc-bc10-11ed-9a44-7ef9696e0000.csc.yml-AEC52C1F0C022CD28C89CE74CD2F58B123CDB5C6",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "422c056f889f12ff8b78db674bb6967bbea60ffb80aa32d18ccf401e17609f1d"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "aec52c1f0c022cd28c89ce74cd2f58b123cdb5c6"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/cam_tool/cam_message.py",
+      "SPDXID": "SPDXRef-File--cam-tool-cam-tool-cam-message.py-AF52202BD621892C4D0C374FCB87EB70F8E3324E",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "fae4b13d938ee9a76202cb6eec1d12e513388bcef0c3b0a8fc50c4aecb9943db"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "af52202bd621892c4d0c374fcb87eb70f8e3324e"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/test_cam_message.py",
+      "SPDXID": "SPDXRef-File--cam-tool-test-test-cam-message.py-B02C92C2EDE06EC43605A4D5F26EF8782C644671",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "f5639c24501c40aeaf12bb1452c9e9649d1b2ceb18e94ee2f3b010e16e5c90fd"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b02c92c2ede06ec43605a4d5f26ef8782c644671"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/expected_msg_output-3",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-expected-msg-output-3-CEC96F2A2E96DCFDD7FDEF02351F15327319943F",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "b745b1996170947f813a8423f2bdd9f532bcc9c2a08e27c8ad866525637cdc62"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "cec96f2a2e96dcfdd7fdef02351f15327319943f"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/empty_file.csc.yml",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-empty-file.csc.yml-DA39A3EE5E6B4B0D3255BFEF95601890AFD80709",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/expected_output.csc",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-expected-output.csc-9A700CBED8FE9BC368E0090B1526547434C41276",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "5648dea3222d2d100fb0ced792253e2b2ea6f8eebbc7ea9fa3a3b19d5a127dba"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "9a700cbed8fe9bc368e0090b1526547434c41276"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/expected_msg_output-2",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-expected-msg-output-2-43816739F32FD401450F1528759953457B1EFE67",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "bcc7efbe8a24351d93307f4b9b19fa570bd52063d23b673507f9e8af2ea853ef"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "43816739f32fd401450f1528759953457b1efe67"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./libcam/CMakeLists.txt",
+      "SPDXID": "SPDXRef-File--libcam-CMakeLists.txt-508BCE3E9654DD5D571CB8D90150585862FE2E15",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "4651133a20d189e873b9d5bc9528864bb75dbd37726b1bdae29648c18544d09e"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "508bce3e9654dd5d571cb8d90150585862fe2e15"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./libcam/src/cam.c",
+      "SPDXID": "SPDXRef-File--libcam-src-cam.c-59D6C20D06B5D434F1FAD43D5CED2A11A5B9695C",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "0d2041b3c5a8f38c9348169fa10c301e0fb7f163050640c187b6de0a149358ee"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "59d6c20d06b5d434f1fad43d5ced2a11a5b9695c"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-uuid/src/cam_uuid.c",
+      "SPDXID": "SPDXRef-File--cam-uuid-src-cam-uuid.c-5DEC9CB37B34642434C84774014D3C2DEF39F507",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "b40de4f5d38a3045932fd5cb901ca508067b162d7114505ad82d7c6af4ee5e9b"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "5dec9cb37b34642434c84774014d3c2def39f507"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/logs/HEAD",
+      "SPDXID": "SPDXRef-File--.git-logs-HEAD-722271669840AAEC922CAABA20363FB2B9193A9B",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "e1d121ad8f429ac0ad7e6a3c478e596739b780240ebdfb953039b6fceae9aa00"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "722271669840aaec922caaba20363fb2b9193a9b"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/hooks/push-to-checkout.sample",
+      "SPDXID": "SPDXRef-File--.git-hooks-push-to-checkout.sample-508240328C8B55F8157C93C43BF5E291E5D2FBCB",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "a53d0741798b287c6dd7afa64aee473f305e65d3f49463bb9d7408ec3b12bf5f"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "508240328c8b55f8157c93c43bf5e291e5d2fbcb"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/hooks/commit-msg.sample",
+      "SPDXID": "SPDXRef-File--.git-hooks-commit-msg.sample-EE1ED5AAD98A435F2020B6DE35C173B75D9AFFAC",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "1f74d5e9292979b573ebd59741d46cb93ff391acdd083d340b94370753d92437"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "ee1ed5aad98a435f2020b6de35c173b75d9affac"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/hooks/pre-push.sample",
+      "SPDXID": "SPDXRef-File--.git-hooks-pre-push.sample-A599B773B930CA83DBC3A5C7C13059AC4A6EAEDC",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ecce9c7e04d3f5dd9d8ada81753dd1d549a9634b26770042b58dda00217d086a"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "a599b773b930ca83dbc3a5c7c13059ac4a6eaedc"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/test/src/test_suite.h",
+      "SPDXID": "SPDXRef-File--cam-service-test-src-test-suite.h-CDF9CDBFD5BBE73D030A9DF8D9665C5C35405A62",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "d7bbbc5501ad593ae8107c1bdea522fb5a6050d4a76ec28f7cf562260b9c9a2e"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "cdf9cdbfd5bbe73d030a9df8d9665c5c35405a62"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/test/fixture/84085ddc-bc10-11ed-9a44-7ef9696e9dd0.csd",
+      "SPDXID": "SPDXRef-File--cam-service-test-fixture-84085ddc-bc10-11ed-9a44-7ef9696e9dd0.csd-89E9678D98B0FC0EE2F9E9F767B164D365C8397A",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "41a976a3cdfdfe6611d58af965165601328130383dbad11e08acc056d22eb0a7"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "89e9678d98b0fc0ee2f9e9f767b164d365c8397a"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/src/cam_service.c",
+      "SPDXID": "SPDXRef-File--cam-service-src-cam-service.c-123EC5C51BE94C6CA827224150CE9DFB50560D51",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "630776c091394827fe465aea9742014c48f96de30f94b61b9a24bab01a9c789f"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "123ec5c51be94c6ca827224150ce9dfb50560d51"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/src/cam_byte_order.h",
+      "SPDXID": "SPDXRef-File--cam-service-src-cam-byte-order.h-CFEE563CC5E62DC268996487B4C493D8BE77FF67",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "f15cc25b761837da89d183a963878fa130a1481dc42c21dd2e7a53055e3d0eac"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "cfee563cc5e62dc268996487b4c493d8be77ff67"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./scripts/generate_spdx_design_sbom.py",
+      "SPDXID": "SPDXRef-File--scripts-generate-spdx-design-sbom.py-F2A347983DC7A3FDFB9208BCD4766CADF7CCBD05",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "3e33cacbeee7480207f20f4ec4ed27ddd61d345d681459a6865b7f079c6b7d32"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "f2a347983dc7a3fdfb9208bcd4766cadf7ccbd05"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-app-example/cam-data/stream2.csc.yml",
+      "SPDXID": "SPDXRef-File--cam-app-example-cam-data-stream2.csc.yml-E9A09C044562B6FB6D37E7E5A5F39235517BEB1F",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "6226156c456ba94c5ba3673230b216c5773c44f748d9420009f12ade878abb16"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "e9a09c044562b6fb6d37e7e5a5f39235517beb1f"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-app-example/src/cmdline.c",
+      "SPDXID": "SPDXRef-File--cam-app-example-src-cmdline.c-DD946FF294E3285DB10F38DCAFF0C0DEF2D2C255",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "95d1bdc7eed0d86f99db2d5a4803797fe6916348ec6f99566a1d1146253b9c21"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "dd946ff294e3285db10f38dcaff0c0def2d2c255"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/cam_tool/cam_csel.py",
+      "SPDXID": "SPDXRef-File--cam-tool-cam-tool-cam-csel.py-B744D0E19032DFCD5A818E1CB7D1F26B95BB9D69",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "a1b9bf0e675e90fa82bc340213731eb9ca67e7130f0f5fff729a21b66c9fbc8d"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b744d0e19032dfcd5a818e1cb7d1f26b95bb9d69"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/__init__.py",
+      "SPDXID": "SPDXRef-File--cam-tool-test---init--.py-99CC0AD65EE34E2C19C7BBE1B2E98783F60C5F26",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "bfc59a3a4292a522d8e62190baf1507868cde61c9b68bcb6543ede78f8bdfa15"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "99cc0ad65ee34e2c19c7bbe1b2e98783f60c5f26"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/valid.csc.yml",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-valid.csc.yml-2713BBCB038082FB82094E01433F40DABC70BD39",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "27224a24a8a909cf5aa560dc48c26ce68df252d9a704283b246b79c7aa072f37"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "2713bbcb038082fb82094e01433f40dabc70bd39"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/no_padding_bytes.csd",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-no-padding-bytes.csd-5737DEED8785E47DDAB3BA109B36A3C7B0637700",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "b67d4e82ebd05f157e5e8a6f0d398e009a8014745b70a63545d873a272f0b52c"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "5737deed8785e47ddab3ba109b36a3c7b0637700"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/no_meta_uuid.csc.yml",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-no-meta-uuid.csc.yml-D094E5DF930C9EB40112BDA356567FE2C81F0CBF",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "44bbb9f73a8f292e0e0a29fa9ae6e5ae89ebfd433fa378d3cf994e820e9fbff8"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "d094e5df930c9eb40112bda356567fe2c81f0cbf"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/success_case.msg_rcv",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-success-case.msg-rcv-531873E1E318A30E191041E59F1E926DCB1F375C",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "2db34ecc317f2336216155705bd35c36f27290c4b347f36a31368994a9ef66aa"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "531873e1e318a30e191041e59f1e926dcb1f375c"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/expected_msg_output-0",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-expected-msg-output-0-42A4902AFCCC45A3244E7E48C58264B267D26275",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "fb36bb731a48ea8725e38e65888bc98a6598bec54b2b4f360020baccf4b597b7"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "42a4902afccc45a3244e7e48c58264b267d26275"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./libcam/test/src/test_libcam.c",
+      "SPDXID": "SPDXRef-File--libcam-test-src-test-libcam.c-FA08DEF8E763F31C6890796AE23AE9477940648D",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "1994ddf2434ef984adf82ff739ddecc5a8892516cb063aeeef08fea4fdd6828c"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "fa08def8e763f31c6890796ae23ae9477940648d"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-uuid/test/src/test_suite.h",
+      "SPDXID": "SPDXRef-File--cam-uuid-test-src-test-suite.h-30E60F13DCD57065C8F3206914794786E9AEBFFF",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "c5572b8e6f334f12975c382b084a76d5b9ec99248a60a8ba426dcf073a51007c"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "30e60f13dcd57065c8f3206914794786e9aebfff"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/description",
+      "SPDXID": "SPDXRef-File--.git-description-9635F1B7E12C045212819DD934D809EF07EFA2F4",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "85ab6c163d43a17ea9cf7788308bca1466f1b0a8d1cc92e26e9bf63da4062aee"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "9635f1b7e12c045212819dd934d809ef07efa2f4"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/objects/pack/pack-dfc8042bd133851dae79f320666964927acd23d6.idx",
+      "SPDXID": "SPDXRef-File--.git-objects-pack-pack-dfc8042bd133851dae79f320666964927acd23d6.idx-03F24A13ADDCB1459046EECE9A979EEB157106FC",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "57c872914714f0f7bc528e9a4cc5b1c822bf05f6fafa50f8a2883ae81920026c"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "03f24a13addcb1459046eece9a979eeb157106fc"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/hooks/sendemail-validate.sample",
+      "SPDXID": "SPDXRef-File--.git-hooks-sendemail-validate.sample-74CF1D5415A5C03C110240F749491297D65C4C98",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "44ebfc923dc5466bc009602f0ecf067b9c65459abfe8868ddc49b78e6ced7a92"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "74cf1d5415a5c03c110240f749491297d65c4c98"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/hooks/update.sample",
+      "SPDXID": "SPDXRef-File--.git-hooks-update.sample-730E6BD5225478BAB6147B7A62A6E2AE21D40507",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "8d5f2fa83e103cf08b57eaa67521df9194f45cbdbcb37da52ad586097a14d106"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "730e6bd5225478bab6147b7a62a6e2ae21d40507"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/test/src/test_suite.c",
+      "SPDXID": "SPDXRef-File--cam-service-test-src-test-suite.c-7D0D164A1D20D1D5AEDC862796C823CB87A07C07",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "e3083409fdedeff946d6f16c9c7f0a805f65c0d666e7fbf922d72a97fbf24a6c"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "7d0d164a1d20d1d5aedc862796c823cb87a07c07"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/test/fixture/84085ddc-bc10-11ed-9a44-7ef9696e9dd6.csd",
+      "SPDXID": "SPDXRef-File--cam-service-test-fixture-84085ddc-bc10-11ed-9a44-7ef9696e9dd6.csd-4D5A978F32A79A23E5A50E3516EF6231F96F977D",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "1bf4b2d2a071dd9d7471c3cc5a921b41cfd346359e0868241e2643530662b45c"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "4d5a978f32a79a23e5a50e3516ef6231f96f977d"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/src/cam_socket.c",
+      "SPDXID": "SPDXRef-File--cam-service-src-cam-socket.c-FEDEC13E382F96C1DFAB5807A1191B0E20F8806D",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "d584d5193cb08f444e44677930b152ad768b58d57b6a804226cbec7332378996"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "fedec13e382f96c1dfab5807a1191b0e20f8806d"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/src/cam_log.c",
+      "SPDXID": "SPDXRef-File--cam-service-src-cam-log.c-6BF27E2BE942C4E0317D22B9027A2BF2527C01AB",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "6b1185d8a7e5abfd9776c94d900faeff742861acb5c679fb037d1583f094f5f4"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6bf27e2be942c4e0317d22b9027a2bf2527c01ab"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/src/cam_stream.c",
+      "SPDXID": "SPDXRef-File--cam-service-src-cam-stream.c-6BE6F090CA5999E487BA9DEB6D0B5E9D2F07BF1F",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "749c4e641aea0c68df21896cd67d46bbc4f16c73f425e867551be78597e2c0c5"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6be6f090ca5999e487ba9deb6d0b5e9d2f07bf1f"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-app-example/cam-data/stream1.csc.yml",
+      "SPDXID": "SPDXRef-File--cam-app-example-cam-data-stream1.csc.yml-9BFED0F18110A8BB2A6A42EECACA79CDC234C7D8",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "5db7d40473e5ca1fd1dd394ac3319daabd2e8f97e0b92b58910c8134ba287f41"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "9bfed0f18110a8bb2a6a42eecaca79cdc234c7d8"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-app-example/src/config.h",
+      "SPDXID": "SPDXRef-File--cam-app-example-src-config.h-9C6DBBA383998473A62FECD67CE030FE8FDF2444",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "905616acbf70339216fe9cbeaf65850f4d4a61eee38a47dcd6dbbce897e5a56c"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "9c6dbba383998473a62fecd67ce030fe8fdf2444"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/cam_tool/__init__.py",
+      "SPDXID": "SPDXRef-File--cam-tool-cam-tool---init--.py-99CC0AD65EE34E2C19C7BBE1B2E98783F60C5F26",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "bfc59a3a4292a522d8e62190baf1507868cde61c9b68bcb6543ede78f8bdfa15"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "99cc0ad65ee34e2c19c7bbe1b2e98783f60c5f26"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/test_cam_csc.py",
+      "SPDXID": "SPDXRef-File--cam-tool-test-test-cam-csc.py-63FD5D70BB8D5AE1B0AC26D8937F9EC6249D2967",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "56fa8322302ef97feaa5ab68ca0827c3965a20b87b03a6559a61426854a0e45f"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "63fd5d70bb8d5ae1b0ac26d8937f9ec6249d2967"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/invalid_mode_id.csc.yml",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-invalid-mode-id.csc.yml-E5B5755AB1159298FC475E58579FB0F69622CB49",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "f5ee89929b1b6a54caf0220df3532b5ab14e4e66ed3a8fcbf4d6f3aedb1ab384"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "e5b5755ab1159298fc475e58579fb0f69622cb49"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/invalid_name.csc.yml",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-invalid-name.csc.yml-97DD33F4CC67022B25DB195EA76742D1D69AB4CE",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "1ae166bade2b42fc90fb599a17e440848e0861e6039ce22e849f483633204bc6"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "97dd33f4cc67022b25db195ea76742d1d69ab4ce"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/invalid_message_size.msg_rcv",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-invalid-message-size.msg-rcv-3339B43BB254748746D13FB535E8FED71A0CF965",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "90aedfcdd9edaadfdb5bca6694add275e13975dbaabfc90700625e1efedc399b"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "3339b43bb254748746d13fb535e8fed71a0cf965"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/expected_msg_output-1",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-expected-msg-output-1-708DB2D675705C43916EA51990AA853EBB69937D",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "91f0038710a910bf0f8a60d3ea50b2cf13d702fd9a4a0cb03673624db75084e3"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "708db2d675705c43916ea51990aa853ebb69937d"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/no_meta_name.csc.yml",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-no-meta-name.csc.yml-A8E9876D88DE9C60EB7618F1B2C5D170FA16EAB2",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "8e4073b0c8cc64453400f57dc4be2be3b547864dc2cd5a2d5d206c96e6877a37"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "a8e9876d88de9c60eb7618f1b2c5d170fa16eab2"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./libcam/test/fixture/expected_output.csel",
+      "SPDXID": "SPDXRef-File--libcam-test-fixture-expected-output.csel-EF6628FAB17D7E0F5F566DBE434362BDB3F228DF",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "55a05e498d7eef4a634d323867880f9c0113fe9ef243c4b356ec650e4869977c"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "ef6628fab17d7e0f5f566dbe434362bdb3f228df"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-uuid/test/src/test_cam_uuid.c",
+      "SPDXID": "SPDXRef-File--cam-uuid-test-src-test-cam-uuid.c-068016D85D9E746E6CDA81B42A760798CE03BEE1",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ca543f4cb66984a335862ca754dfa84f13a96c9c234145334d50a5d305e9db8e"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "068016d85d9e746e6cda81b42a760798ce03bee1"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/FETCH_HEAD",
+      "SPDXID": "SPDXRef-File--.git-FETCH-HEAD-64D9188E0850137AF3C88E50F59B824732C909B6",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "31d88240c92dee469298d0a86b980f2c98cfa8f98f172655f0c9abde17fc1f22"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "64d9188e0850137af3c88e50f59b824732c909b6"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/hooks/pre-push",
+      "SPDXID": "SPDXRef-File--.git-hooks-pre-push-6145042684084DFE68CED3427E8F0A7671276831",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "a52d0510d0f8c75e27852156ec6f7791f0d8ed65fc58fcc368dd1de0a60a1d74"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6145042684084dfe68ced3427e8f0a7671276831"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/hooks/pre-commit.sample",
+      "SPDXID": "SPDXRef-File--.git-hooks-pre-commit.sample-8093D68E142DB52DCAB2215E770BA0BBE4CFBF24",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "57185b7b9f05239d7ab52db045f5b89eb31348d7b2177eab214f5eb872e1971b"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "8093d68e142db52dcab2215e770ba0bbe4cfbf24"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/hooks/post-merge",
+      "SPDXID": "SPDXRef-File--.git-hooks-post-merge-02D6A0E420A63C99AA9ACD43445F0D8DC99E35E3",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "cecb594e8fa65831654fc95e96db9f1249e09c52810c6fbb2b428280aac22158"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "02d6a0e420a63c99aa9acd43445f0d8dc99e35e3"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/test/src/test_cam_config.c",
+      "SPDXID": "SPDXRef-File--cam-service-test-src-test-cam-config.c-3A4770126BF91DD692B1134A7B9C7EB2BFD15DDA",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "81898e1bf48d5730cf1768d139bae4805f6291d26c6ebf8dbc300de8d40664dd"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "3a4770126bf91dd692b1134a7b9c7eb2bfd15dda"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/test/fixture/84085ddc-bc10-11ed-9a44-7ef9696e9dd9.csd",
+      "SPDXID": "SPDXRef-File--cam-service-test-fixture-84085ddc-bc10-11ed-9a44-7ef9696e9dd9.csd-73C7E4D2BF01A74515C7AD0D73A7A4CCAC333D0D",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "7fe5b50bed5d0c9aea39e59f1302efdccdf9c67f771d010a871bac072ce7ac9d"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "73c7e4d2bf01a74515c7ad0d73a7a4ccac333d0d"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/src/cam_cmdline.h",
+      "SPDXID": "SPDXRef-File--cam-service-src-cam-cmdline.h-435C56EE8A65A388D42B1FBF03CC824AE3CE3DB2",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "8babb099f512d5625bd312f29c46ed02541f2c32ce8446ced482b0043bf9e44f"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "435c56ee8a65a388d42b1fbf03cc824ae3ce3db2"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/src/cam_fault_driver_itf.h",
+      "SPDXID": "SPDXRef-File--cam-service-src-cam-fault-driver-itf.h-B1BFF13B18EA906B194D5601C2F2C621BACFF032",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "bfeb2ecc264a45f14805208ab532bfaa8a045674e48f771bfac7498760309af6"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b1bff13b18ea906b194d5601c2f2c621bacff032"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./scripts/lint_strictdoc_traceability.py",
+      "SPDXID": "SPDXRef-File--scripts-lint-strictdoc-traceability.py-DDD7CB87C23A9016FF55BA965C2C66EF8CCB26B5",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "0b4b14ad9129d1d51793d1dc1864fb4f278e0562a85d91be9fba0eb41890a961"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "ddd7cb87c23a9016ff55ba965c2c66ef8ccb26b5"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-app-example/cam-data/84085ddc-bc10-11ed-9a44-7ef9696e0002.csd",
+      "SPDXID": "SPDXRef-File--cam-app-example-cam-data-84085ddc-bc10-11ed-9a44-7ef9696e0002.csd-9317AC28B80E0F83656B969251B9AE660324F4F2",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "b2bd39d8dd2d723440e9b312b7e2b8073b8d2820e377d369e487592f03574df5"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "9317ac28b80e0f83656b969251b9ae660324f4f2"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-app-example/src/example.c",
+      "SPDXID": "SPDXRef-File--cam-app-example-src-example.c-4B8C84FFA35341D013DD91567C62A8E451F789D3",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "4dd4f60f039db1e4305deb898f98476c2ea8ead8225b0ab04df513c45786405c"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "4b8c84ffa35341d013dd91567c62a8e451f789d3"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/cam_tool/cam_tool_run.py",
+      "SPDXID": "SPDXRef-File--cam-tool-cam-tool-cam-tool-run.py-B10839D60E38CC0EC8953A8D10B1DC7824738A04",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "05251e90479c7509827c90302363792097ab84b1c284c0af8c146214f8f4a607"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b10839d60e38cc0ec8953a8d10b1dc7824738a04"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/valid.csel",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-valid.csel-3329494445A06C421C84B682F60CF28FEF665F5A",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "47eca3b1c53732e03da56ead7880918a283b59ded6236e4a70224dfb42b2d2cd"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "3329494445a06c421c84b682f60cf28fef665f5a"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/non_periodic_event_entry.csel",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-non-periodic-event-entry.csel-CE978035A715CF666F14200CDB14A0DFA3897A29",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "23dc5d05f2039dc43d844de00d265369c1289ba37e6906ac9fb0f7b62a963c53"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "ce978035a715cf666f14200cdb14a0dfa3897a29"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/out_of_period_event_id.csel",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-out-of-period-event-id.csel-B0C7D1F868D84A1BB4EAABD3486A15B1CBCC0C8A",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "4bbec750a7dcc9b4f24165bffcd7a51f5ee4429c74ee15413caaa0383bf11a31"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b0c7d1f868d84a1bb4eaabd3486a15b1cbcc0c8a"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/no_alarms.csc.yml",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-no-alarms.csc.yml-F6D3CA69987F234B05AEC738CC90E110688804CD",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "daae054011b0e5e76ebbbea3ff3c90e863e0e15a39de6fef946cf779f82b2e28"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "f6d3ca69987f234b05aec738cc90e110688804cd"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/invalid_entry_format.csel",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-invalid-entry-format.csel-093D75799B926A2DF78DD3A00A092EFCF9974EEE",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "92d1393e8924210583e7cffe27f457e8861b6743fd991b94e14b201dbac92332"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "093d75799b926a2df78dd3a00a092efcf9974eee"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./libcam/include/cam.h",
+      "SPDXID": "SPDXRef-File--libcam-include-cam.h-7553478E86CC65768C7F2062779288069F681AE7",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "4d6a07fd21cb41a26482786ab85fd346a8d912c2a45ff68f9301711f22757cf9"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "7553478e86cc65768c7f2062779288069f681ae7"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-uuid/CMakeLists.txt",
+      "SPDXID": "SPDXRef-File--cam-uuid-CMakeLists.txt-429DF1FA2038DECE612F82FBE72D8A1D0DD1DB7A",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "8e845d98fe6f5675f98cdef1a44bebc03edaad21016a27c470b139983bff9f4c"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "429df1fa2038dece612f82fbe72d8a1d0dd1db7a"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/index",
+      "SPDXID": "SPDXRef-File--.git-index-26DF08327E8B379E21CCA77C361447E6718622D5",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "95d1656e2046c39b39ae688d1eff4217bc646c82af68672013b4d7329b2f98f8"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "26df08327e8b379e21cca77c361447e6718622d5"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/logs/refs/heads/main",
+      "SPDXID": "SPDXRef-File--.git-logs-refs-heads-main-705382C8B0DC69F826E421508D7CD946BD20C5F5",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "80160792ecae6406f60dc8696031fee7cf7e81387997cb4559016b1953746c03"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "705382c8b0dc69f826e421508d7cd946bd20c5f5"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/hooks/fsmonitor-watchman.sample",
+      "SPDXID": "SPDXRef-File--.git-hooks-fsmonitor-watchman.sample-0EC0EC9AC11111433D17EA79E0AE8CEC650DCFA4",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "e0549964e93897b519bd8e333c037e51fff0f88ba13e086a331592bf801fa1d0"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "0ec0ec9ac11111433d17ea79e0ae8cec650dcfa4"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/hooks/post-checkout",
+      "SPDXID": "SPDXRef-File--.git-hooks-post-checkout-34CCA5E573F14E1C8F36C447FD5005D7D93EBEA7",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "8d606e58cce98604696a4abcf3ae1ebde6f9f31ac72bb0d44e2444cc39f26030"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "34cca5e573f14e1c8f36c447fd5005d7d93ebea7"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/refs/heads/main",
+      "SPDXID": "SPDXRef-File--.git-refs-heads-main-51A5D749C236F93BE2E93DFD8D1AA64D4F4069C9",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "0072b03c49123bfce468ef54cbe0aabe0399fcc2fb2a9da3ce27b95694f595bc"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "51a5d749c236f93be2e93dfd8d1aa64d4f4069c9"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/test/src/test_cam_stream.c",
+      "SPDXID": "SPDXRef-File--cam-service-test-src-test-cam-stream.c-B1E0B2B807A8E108C8DB45C86745A51AD9E84A97",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "fbb335fb990249a683182b47f433501c54c3ce521d404296df27ac0e63cb61a3"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b1e0b2b807a8e108c8db45c86745a51ad9e84a97"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/test/fixture/84085ddc-bc10-11ed-9a44-7ef9696e9dd3.csd",
+      "SPDXID": "SPDXRef-File--cam-service-test-fixture-84085ddc-bc10-11ed-9a44-7ef9696e9dd3.csd-AE0F24D8FAB62DD878E6409B64F97A026EC7126F",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "5f42560eaa5a41e5c27bb16f890bd472b6bfddad3590397fb2e3e340f92d3027"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "ae0f24d8fab62dd878e6409b64f97a026ec7126f"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/src/cam_log.h",
+      "SPDXID": "SPDXRef-File--cam-service-src-cam-log.h-AD17683053FB4982EDF858A8C96A0F7244B0D077",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "d2cd0f9141846f995863738d1a23c1709b7bb8f7af473db13ffc9add7ccd2365"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "ad17683053fb4982edf858a8c96a0f7244b0d077"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/src/cam_fault.c",
+      "SPDXID": "SPDXRef-File--cam-service-src-cam-fault.c-062A76F5FDECA2B53E0632CDF727B831F1DCA408",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ecf580061fc6e6f0517fad6eaaecd26b67fc42717dcde0d995352935651df796"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "062a76f5fdeca2b53e0632cdf727b831f1dca408"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./Dockerfiles/cam-image/Dockerfile",
+      "SPDXID": "SPDXRef-File--Dockerfiles-cam-image-Dockerfile-9B16B2BA2DD4FAEE61BF68D3991DB04B59FAF302",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ba9866a604f01c91df79aa7185a406b4336ff2f08194067692defd6715f8abd2"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "9b16b2ba2dd4faee61bf68d3991db04b59faf302"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-app-example/cam-data/84085ddc-bc10-11ed-9a44-7ef9696e0003.csd",
+      "SPDXID": "SPDXRef-File--cam-app-example-cam-data-84085ddc-bc10-11ed-9a44-7ef9696e0003.csd-6F6ACA5EE68C3C576D862B5C766060F53E2EA828",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "76f6f0494c1fdf9afae727f3a21fec911497957e4f4219db7653e098e5ed2ea1"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6f6aca5ee68c3c576d862b5c766060f53e2ea828"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/cam_tool/cam_csc.py",
+      "SPDXID": "SPDXRef-File--cam-tool-cam-tool-cam-csc.py-BA3F1CA77C45DCCD8FCC35CD35C14324C74E4A5D",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "64aa02982186f4f66cc5bde5dd4c25ae56a5b0d41dd53be596e2c718b5dc6751"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "ba3f1ca77c45dccd8fcc35cd35c14324c74e4a5d"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/invalid_uuid.csc.yml",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-invalid-uuid.csc.yml-497E5EC9D9ABDC9F0B43CA943F8BD4208E5E8980",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "eb6f1bc010ef9693f21b42deaa9aa9896a5ba7305806b98fd832f984c9e5ec2f"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "497e5ec9d9abdc9f0b43ca943f8bd4208e5e8980"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/error_case.msg_rcv",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-error-case.msg-rcv-6BD54C8B87265DCC3D62590E8CFCC543F713343D",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "fc9057747fd73d840a52511d23a87038103cd750711e6b2dee974926dd3c3b7b"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6bd54c8b87265dcc3d62590e8cfcc543f713343d"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/invalid_entry_sequence.csel",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-invalid-entry-sequence.csel-F71D87F20E75D641F4302E4D6AC4056CEEDAD090",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ad654662e41168c38c71126dedee0356926a89ef79916c164f0510e7982bdb10"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "f71d87f20e75d641f4302e4d6ac4056ceedad090"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/invalid_protocol_version.msg_rcv",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-invalid-protocol-version.msg-rcv-3F7A1905CD1D0B9B8C774C8E03363A123849E198",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "bc2a0d642bb05e3eea490f325a959374f599cd8e6c9833c492a702bb29a894c2"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "3f7a1905cd1d0b9b8c774c8e03363a123849e198"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/invalid_sequence_id.csel",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-invalid-sequence-id.csel-7918B1E5EA8F47236E74EA21438F97F66012F51E",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "fbe7f8e9480432f9c2d85c0a50339d848b3edbcac9ebace4b69024425134ff6b"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "7918b1e5ea8f47236e74ea21438f97f66012f51e"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./libcam/test/CMakeLists.txt",
+      "SPDXID": "SPDXRef-File--libcam-test-CMakeLists.txt-6D2DD90E4E04C809BF7701766993E69468AB5D1D",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "acfaef0d7a7b08b1bdb72f58a4db983646f4ef1c5e9aa6d1f1c71b5c4e009498"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6d2dd90e4e04c809bf7701766993e69468ab5d1d"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-uuid/include/cam_uuid.h",
+      "SPDXID": "SPDXRef-File--cam-uuid-include-cam-uuid.h-FF38CAD2730F332982C8A7801C328D3D27AB18ED",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "964e8e9704e965a36a7bea51fb0828ac081c208a99625362332a566d4e763fe3"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "ff38cad2730f332982c8a7801c328d3d27ab18ed"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/config",
+      "SPDXID": "SPDXRef-File--.git-config-A849161D8344C5A6C71C134DAEAF92DB177CDE92",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "03c93ba2a0b005312dcb7c446a284ba8e11236211a60bb60beee97f4889cfcce"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "a849161d8344c5a6c71c134daeaf92db177cde92"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/info/exclude",
+      "SPDXID": "SPDXRef-File--.git-info-exclude-C879DF015D97615050AFA7B9641E3352A1E701AC",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "6671fe83b7a07c8932ee89164d1f2793b2318058eb8b98dc5c06ee0a5a3b0ec1"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c879df015d97615050afa7b9641e3352a1e701ac"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/hooks/pre-receive.sample",
+      "SPDXID": "SPDXRef-File--.git-hooks-pre-receive.sample-705A17D259E7896F0082FE2E9F2C0C3B127BE5AC",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "a4c3d2b9c7bb3fd8d1441c31bd4ee71a595d66b44fcf49ddb310252320169989"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "705a17d259e7896f0082fe2e9f2c0c3b127be5ac"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/hooks/applypatch-msg.sample",
+      "SPDXID": "SPDXRef-File--.git-hooks-applypatch-msg.sample-4DE88EB95A5E93FD27E78B5FB3B5231A8D8917DD",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "0223497a0b8b033aa58a3a521b8629869386cf7ab0e2f101963d328aa62193f7"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "4de88eb95a5e93fd27e78b5fb3b5231a8d8917dd"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/CMakeLists.txt",
+      "SPDXID": "SPDXRef-File--cam-service-CMakeLists.txt-A344D3B230198DDB4E746D5D6294A24E55E3F590",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "bad58e124e833cdb466e6b6a0c106a5a0444b600174318e6a32982dfb42a7a80"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "a344d3b230198ddb4e746d5d6294a24e55e3f590"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/test/src/test_cam_fault.c",
+      "SPDXID": "SPDXRef-File--cam-service-test-src-test-cam-fault.c-C794D099ACB222BD254970C4B46A1B18DBDC1BE5",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "2267d5e7fb4642e9c9476be682beaa4263ec08b341b507e8faabaae082aed467"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c794d099acb222bd254970c4b46a1b18dbdc1be5"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/test/fixture/84085ddc-bc10-11ed-9a44-7ef9696e9dd8.csd",
+      "SPDXID": "SPDXRef-File--cam-service-test-fixture-84085ddc-bc10-11ed-9a44-7ef9696e9dd8.csd-4653DBEDB4C09D685AC8662927D0CFB1A48A9BF1",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "739ec5eb5128b62cef332dea1f09cc6f7b68411506b475f42b7f2262192b726d"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "4653dbedb4c09d685ac8662927d0cfb1a48a9bf1"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/src/cam_cmdline.c",
+      "SPDXID": "SPDXRef-File--cam-service-src-cam-cmdline.c-8AAD45DCCC0F09F9D4653920E6E3BEC1B9B239EB",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "5051d591a3b5f460414abc5810c5a825c27a997e2f60674e729d1f496159ecf7"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "8aad45dccc0f09f9d4653920e6e3bec1b9b239eb"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/src/cam_fault.h",
+      "SPDXID": "SPDXRef-File--cam-service-src-cam-fault.h-8A8573270E076ECE7A088118CB9DF4FA18C1B0CB",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "38fb3b5d27e50aaee9be9810423a94a243bca57028da021481863089678f8c1b"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "8a8573270e076ece7a088118cb9df4fa18c1b0cb"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./Dockerfiles/cam-image-zephyr/Dockerfile",
+      "SPDXID": "SPDXRef-File--Dockerfiles-cam-image-zephyr-Dockerfile-A497A8BC79C5A8AF188A18C5C466C70583FE4EDD",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "539c7854aa004cb225ed8dc59ef4804bf8f22151b62e2aaa432be763a7aa711e"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "a497a8bc79c5a8af188a18c5c466c70583fe4edd"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-app-example/cam-data/stream0.csc.yml",
+      "SPDXID": "SPDXRef-File--cam-app-example-cam-data-stream0.csc.yml-05B5987F38DC99E6B363989912B8DB3E92227614",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "5709f272ebe7c15df9abbcfe18ec327991ae7d142d57af79d3bc22279a72b3c9"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "05b5987f38dc99e6b363989912b8db3e92227614"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/objects/pack/pack-dfc8042bd133851dae79f320666964927acd23d6.pack",
+      "SPDXID": "SPDXRef-File--.git-objects-pack-pack-dfc8042bd133851dae79f320666964927acd23d6.pack-8E41A3A56BE2D553C1CB127AAA654A36EECD5227",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "68ff9673e9ea5bb0e03c3bc158916081ec1e910f74d3a0dab2f295b7ae2ee622"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "8e41a3a56be2d553c1cb127aaa654a36eecd5227"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/hooks/post-update.sample",
+      "SPDXID": "SPDXRef-File--.git-hooks-post-update.sample-B614C2F63DA7DCA9F1DB2E7ADE61EF30448FC96C",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "81765af2daef323061dcbc5e61fc16481cb74b3bac9ad8a174b186523586f6c5"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b614c2f63da7dca9f1db2e7ade61ef30448fc96c"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/hooks/pre-merge-commit.sample",
+      "SPDXID": "SPDXRef-File--.git-hooks-pre-merge-commit.sample-04C64E58BC25C149482ED45DBD79E40EFFB89EB7",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "d3825a70337940ebbd0a5c072984e13245920cdf8898bd225c8d27a6dfc9cb53"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "04c64e58bc25c149482ed45dbd79e40effb89eb7"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/test/CMakeLists.txt",
+      "SPDXID": "SPDXRef-File--cam-service-test-CMakeLists.txt-6EF2225B24DA4CCBA84F68EA89D96503E208C29D",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "1a8f789449307ed9da4f75400e7e8641323efc17fd1ce4937588cf26f978d582"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6ef2225b24da4ccba84f68ea89d96503e208c29d"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/test/src/test_cam_socket.c",
+      "SPDXID": "SPDXRef-File--cam-service-test-src-test-cam-socket.c-DC3E53359233F8D64E9717A909A03EFC9307CC92",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "7f3377627faca839db347fb40735c0a05a5f0a6bc811fc9fef8cdd5a474a6e32"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "dc3e53359233f8d64e9717a909a03efc9307cc92"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/test/fixture/84085ddc-bc10-11ed-9a44-7ef9696e9dd7.csd",
+      "SPDXID": "SPDXRef-File--cam-service-test-fixture-84085ddc-bc10-11ed-9a44-7ef9696e9dd7.csd-CBE5C5E17960713783A419D122433B548A78E933",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "dd06ff27133cbacc67498534ced0b5f1155d16c7d2cfd7c390d0c3b3e0f103f1"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "cbe5c5e17960713783a419d122433b548a78e933"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/src/cam_stream.h",
+      "SPDXID": "SPDXRef-File--cam-service-src-cam-stream.h-07CC268E59C3E5286D0EEF70E55D50D18B40B82E",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "5df2a2104db4ab5a5cafca3397c0e2eaf5f5750db295707938b8f19066d87755"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "07cc268e59c3e5286d0eef70e55d50d18b40b82e"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/src/cam_config.h",
+      "SPDXID": "SPDXRef-File--cam-service-src-cam-config.h-983C9B066BDEDEF0B10DF31CCB8B390CC0D5B0A5",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "3fcfeeef52d8b6d726169dcf3e184c8f04a5112ebcd01c7d053ecde2c06d2025"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "983c9b066bdedef0b10df31ccb8b390cc0d5b0a5"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-app-example/CMakeLists.txt",
+      "SPDXID": "SPDXRef-File--cam-app-example-CMakeLists.txt-7CE727E657055E814EA31C91E9C3C4D8525129EB",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "128013dbc43ed52c538fa7f167f059780299bf9eaa275c8f9092c19698777cfc"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "7ce727e657055e814ea31c91e9c3c4d8525129eb"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-app-example/cam-data/84085ddc-bc10-11ed-9a44-7ef9696e0001.csd",
+      "SPDXID": "SPDXRef-File--cam-app-example-cam-data-84085ddc-bc10-11ed-9a44-7ef9696e0001.csd-CA32F5D6E9EE31C51FD93739834F7FF67E0AAA93",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ac74c5ab104d3cc732e1bad44bd008fbdb86fe85bd6bea20d7cf6d1ca97edd07"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "ca32f5d6e9ee31c51fd93739834f7ff67e0aaa93"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    }
+  ],
+  "packages": [
+    {
+      "name": "sphinx",
+      "SPDXID": "SPDXRef-Package-87749F3F5444B22B14A14E3607A49BA23BCDAEDF24C51964277B625FD9FD4967",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "copyrightText": "NOASSERTION",
+      "versionInfo": "6.1.3",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:pypi/sphinx@6.1.3"
+        }
+      ],
+      "supplier": "NOASSERTION"
+    },
+    {
+      "name": "pytest",
+      "SPDXID": "SPDXRef-Package-C99E2E1E6C0E9A26D42002AD18B5C4EC3DD2F09BF57BDC6A772477CFBC5B33D1",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "copyrightText": "NOASSERTION",
+      "versionInfo": "7.1.2",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:pypi/pytest@7.1.2"
+        }
+      ],
+      "supplier": "NOASSERTION"
+    },
+    {
+      "name": "readthedocs-sphinx-search",
+      "SPDXID": "SPDXRef-Package-3F012714C432ACDFE4FC4261380361E90457B9E6DA4933C8205A749D16624AD3",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "copyrightText": "NOASSERTION",
+      "versionInfo": "0.3.2",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:pypi/readthedocs-sphinx-search@0.3.2"
+        }
+      ],
+      "supplier": "NOASSERTION"
+    },
+    {
+      "name": "sphinxcontrib-googleanalytics",
+      "SPDXID": "SPDXRef-Package-501BDE8C2898B8F7C7CE89A8E40E4EE4137C22696CD458B85DDC6F4C505B5C05",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "copyrightText": "NOASSERTION",
+      "versionInfo": "0.4",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:pypi/sphinxcontrib-googleanalytics@0.4"
+        }
+      ],
+      "supplier": "NOASSERTION"
+    },
+    {
+      "name": "sphinx-rtd-theme",
+      "SPDXID": "SPDXRef-Package-4DEA190FC8CE8EE0F406A9FF1F755BA738B18B7A986FF9D7E7F3731248E81E75",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "copyrightText": "NOASSERTION",
+      "versionInfo": "2.0.0",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:pypi/sphinx-rtd-theme@2.0.0"
+        }
+      ],
+      "supplier": "NOASSERTION"
+    },
+    {
+      "name": "sphinx-substitution-extensions",
+      "SPDXID": "SPDXRef-Package-25A88B0E02EA9C9A3AF567240D2E9383B7A0B6C2B0D847431A58F42A9C2D6779",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "copyrightText": "NOASSERTION",
+      "versionInfo": "2022.2.16",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:pypi/sphinx-substitution-extensions@2022.2.16"
+        }
+      ],
+      "supplier": "NOASSERTION"
+    },
+    {
+      "name": "pyyaml",
+      "SPDXID": "SPDXRef-Package-608734958F785BCA948551853649C7FC98B52E5D2060EC426F90714C5A70228D",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "copyrightText": "NOASSERTION",
+      "versionInfo": "6.0",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:pypi/pyyaml@6.0"
+        }
+      ],
+      "supplier": "NOASSERTION"
+    },
+    {
+      "name": "sphinx-copybutton",
+      "SPDXID": "SPDXRef-Package-F891BD098C2683819984852B8A47264307A6F37C7CB948CEA205390A27FED40D",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "copyrightText": "NOASSERTION",
+      "versionInfo": "0.5.2",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:pypi/sphinx-copybutton@0.5.2"
+        }
+      ],
+      "supplier": "NOASSERTION"
+    },
+    {
+      "name": "from_root",
+      "SPDXID": "SPDXRef-Package-997BB0F681869CA98D5667676CD5B68622673C2FEF7DC8A74C4063DC206A7218",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "copyrightText": "NOASSERTION",
+      "versionInfo": "1.3.0",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:pypi/from-root@1.3.0"
+        }
+      ],
+      "supplier": "NOASSERTION"
+    },
+    {
+      "name": "breathe",
+      "SPDXID": "SPDXRef-Package-480871C937AB17B2CA00697B94806F3B668E9C726D662774832FD26A33E9C973",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "copyrightText": "NOASSERTION",
+      "versionInfo": "4.35.0",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:pypi/breathe@4.35.0"
+        }
+      ],
+      "supplier": "NOASSERTION"
+    },
+    {
+      "name": "im-customers-arm/arm-critical-app-monitoring",
+      "SPDXID": "SPDXRef-RootPackage",
+      "downloadLocation": "NOASSERTION",
+      "packageVerificationCode": {
+        "packageVerificationCodeValue": "37ca8912e0d550a632050dd47205552772b0b05f"
+      },
+      "filesAnalyzed": true,
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoFromFiles": [
+        "NOASSERTION"
+      ],
+      "licenseDeclared": "NOASSERTION",
+      "copyrightText": "NOASSERTION",
+      "versionInfo": "1.0.0",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:swid/OwnerName/sbom.infomagnus.com/im-customers-arm%2Farm-critical-app-monitoring@1.0.0?tag_id=910f7276-d4e1-4268-969f-7b6222f43030"
+        }
+      ],
+      "supplier": "Organization: OwnerName",
+      "hasFiles": [
+        "SPDXRef-File--.git-objects-pack-pack-dfc8042bd133851dae79f320666964927acd23d6.pack-8E41A3A56BE2D553C1CB127AAA654A36EECD5227",
+        "SPDXRef-File--cam-app-example-cam-data-stream0.csc.yml-05B5987F38DC99E6B363989912B8DB3E92227614",
+        "SPDXRef-File--Dockerfiles-cam-image-zephyr-Dockerfile-A497A8BC79C5A8AF188A18C5C466C70583FE4EDD",
+        "SPDXRef-File--cam-service-src-cam-fault.h-8A8573270E076ECE7A088118CB9DF4FA18C1B0CB",
+        "SPDXRef-File--cam-service-src-cam-cmdline.c-8AAD45DCCC0F09F9D4653920E6E3BEC1B9B239EB",
+        "SPDXRef-File--cam-service-test-fixture-84085ddc-bc10-11ed-9a44-7ef9696e9dd8.csd-4653DBEDB4C09D685AC8662927D0CFB1A48A9BF1",
+        "SPDXRef-File--cam-service-test-src-test-cam-fault.c-C794D099ACB222BD254970C4B46A1B18DBDC1BE5",
+        "SPDXRef-File--cam-service-CMakeLists.txt-A344D3B230198DDB4E746D5D6294A24E55E3F590",
+        "SPDXRef-File--.git-hooks-applypatch-msg.sample-4DE88EB95A5E93FD27E78B5FB3B5231A8D8917DD",
+        "SPDXRef-File--.git-hooks-pre-receive.sample-705A17D259E7896F0082FE2E9F2C0C3B127BE5AC",
+        "SPDXRef-File--.git-info-exclude-C879DF015D97615050AFA7B9641E3352A1E701AC",
+        "SPDXRef-File--.git-config-A849161D8344C5A6C71C134DAEAF92DB177CDE92",
+        "SPDXRef-File--cam-uuid-include-cam-uuid.h-FF38CAD2730F332982C8A7801C328D3D27AB18ED",
+        "SPDXRef-File--libcam-test-CMakeLists.txt-6D2DD90E4E04C809BF7701766993E69468AB5D1D",
+        "SPDXRef-File--cam-tool-test-fixture-invalid-sequence-id.csel-7918B1E5EA8F47236E74EA21438F97F66012F51E",
+        "SPDXRef-File--cam-tool-test-fixture-invalid-protocol-version.msg-rcv-3F7A1905CD1D0B9B8C774C8E03363A123849E198",
+        "SPDXRef-File--cam-tool-test-fixture-invalid-entry-sequence.csel-F71D87F20E75D641F4302E4D6AC4056CEEDAD090",
+        "SPDXRef-File--cam-tool-test-fixture-error-case.msg-rcv-6BD54C8B87265DCC3D62590E8CFCC543F713343D",
+        "SPDXRef-File--cam-tool-test-fixture-invalid-uuid.csc.yml-497E5EC9D9ABDC9F0B43CA943F8BD4208E5E8980",
+        "SPDXRef-File--cam-tool-cam-tool-cam-csc.py-BA3F1CA77C45DCCD8FCC35CD35C14324C74E4A5D",
+        "SPDXRef-File--cam-app-example-cam-data-84085ddc-bc10-11ed-9a44-7ef9696e0003.csd-6F6ACA5EE68C3C576D862B5C766060F53E2EA828",
+        "SPDXRef-File--Dockerfiles-cam-image-Dockerfile-9B16B2BA2DD4FAEE61BF68D3991DB04B59FAF302",
+        "SPDXRef-File--cam-service-src-cam-fault.c-062A76F5FDECA2B53E0632CDF727B831F1DCA408",
+        "SPDXRef-File--cam-service-src-cam-log.h-AD17683053FB4982EDF858A8C96A0F7244B0D077",
+        "SPDXRef-File--cam-service-test-fixture-84085ddc-bc10-11ed-9a44-7ef9696e9dd3.csd-AE0F24D8FAB62DD878E6409B64F97A026EC7126F",
+        "SPDXRef-File--cam-service-test-src-test-cam-stream.c-B1E0B2B807A8E108C8DB45C86745A51AD9E84A97",
+        "SPDXRef-File--.git-refs-heads-main-51A5D749C236F93BE2E93DFD8D1AA64D4F4069C9",
+        "SPDXRef-File--.git-hooks-post-checkout-34CCA5E573F14E1C8F36C447FD5005D7D93EBEA7",
+        "SPDXRef-File--.git-hooks-fsmonitor-watchman.sample-0EC0EC9AC11111433D17EA79E0AE8CEC650DCFA4",
+        "SPDXRef-File--.git-logs-refs-heads-main-705382C8B0DC69F826E421508D7CD946BD20C5F5",
+        "SPDXRef-File--.git-index-26DF08327E8B379E21CCA77C361447E6718622D5",
+        "SPDXRef-File--cam-uuid-CMakeLists.txt-429DF1FA2038DECE612F82FBE72D8A1D0DD1DB7A",
+        "SPDXRef-File--libcam-include-cam.h-7553478E86CC65768C7F2062779288069F681AE7",
+        "SPDXRef-File--cam-tool-test-fixture-invalid-entry-format.csel-093D75799B926A2DF78DD3A00A092EFCF9974EEE",
+        "SPDXRef-File--cam-tool-test-fixture-no-alarms.csc.yml-F6D3CA69987F234B05AEC738CC90E110688804CD",
+        "SPDXRef-File--cam-tool-test-fixture-out-of-period-event-id.csel-B0C7D1F868D84A1BB4EAABD3486A15B1CBCC0C8A",
+        "SPDXRef-File--cam-tool-test-fixture-non-periodic-event-entry.csel-CE978035A715CF666F14200CDB14A0DFA3897A29",
+        "SPDXRef-File--cam-tool-test-fixture-valid.csel-3329494445A06C421C84B682F60CF28FEF665F5A",
+        "SPDXRef-File--cam-tool-cam-tool-cam-tool-run.py-B10839D60E38CC0EC8953A8D10B1DC7824738A04",
+        "SPDXRef-File--cam-app-example-src-example.c-4B8C84FFA35341D013DD91567C62A8E451F789D3",
+        "SPDXRef-File--cam-app-example-cam-data-84085ddc-bc10-11ed-9a44-7ef9696e0002.csd-9317AC28B80E0F83656B969251B9AE660324F4F2",
+        "SPDXRef-File--scripts-lint-strictdoc-traceability.py-DDD7CB87C23A9016FF55BA965C2C66EF8CCB26B5",
+        "SPDXRef-File--cam-service-src-cam-fault-driver-itf.h-B1BFF13B18EA906B194D5601C2F2C621BACFF032",
+        "SPDXRef-File--cam-service-src-cam-cmdline.h-435C56EE8A65A388D42B1FBF03CC824AE3CE3DB2",
+        "SPDXRef-File--cam-service-test-fixture-84085ddc-bc10-11ed-9a44-7ef9696e9dd9.csd-73C7E4D2BF01A74515C7AD0D73A7A4CCAC333D0D",
+        "SPDXRef-File--cam-service-test-src-test-cam-config.c-3A4770126BF91DD692B1134A7B9C7EB2BFD15DDA",
+        "SPDXRef-File--.git-hooks-post-merge-02D6A0E420A63C99AA9ACD43445F0D8DC99E35E3",
+        "SPDXRef-File--.git-hooks-pre-commit.sample-8093D68E142DB52DCAB2215E770BA0BBE4CFBF24",
+        "SPDXRef-File--.git-hooks-pre-push-6145042684084DFE68CED3427E8F0A7671276831",
+        "SPDXRef-File--.git-FETCH-HEAD-64D9188E0850137AF3C88E50F59B824732C909B6",
+        "SPDXRef-File--cam-uuid-test-src-test-cam-uuid.c-068016D85D9E746E6CDA81B42A760798CE03BEE1",
+        "SPDXRef-File--libcam-test-fixture-expected-output.csel-EF6628FAB17D7E0F5F566DBE434362BDB3F228DF",
+        "SPDXRef-File--cam-tool-test-fixture-no-meta-name.csc.yml-A8E9876D88DE9C60EB7618F1B2C5D170FA16EAB2",
+        "SPDXRef-File--cam-tool-test-fixture-expected-msg-output-1-708DB2D675705C43916EA51990AA853EBB69937D",
+        "SPDXRef-File--cam-tool-test-fixture-invalid-message-size.msg-rcv-3339B43BB254748746D13FB535E8FED71A0CF965",
+        "SPDXRef-File--cam-tool-test-fixture-invalid-name.csc.yml-97DD33F4CC67022B25DB195EA76742D1D69AB4CE",
+        "SPDXRef-File--cam-tool-test-fixture-invalid-mode-id.csc.yml-E5B5755AB1159298FC475E58579FB0F69622CB49",
+        "SPDXRef-File--cam-tool-test-test-cam-csc.py-63FD5D70BB8D5AE1B0AC26D8937F9EC6249D2967",
+        "SPDXRef-File--cam-tool-cam-tool---init--.py-99CC0AD65EE34E2C19C7BBE1B2E98783F60C5F26",
+        "SPDXRef-File--cam-app-example-src-config.h-9C6DBBA383998473A62FECD67CE030FE8FDF2444",
+        "SPDXRef-File--cam-app-example-cam-data-stream1.csc.yml-9BFED0F18110A8BB2A6A42EECACA79CDC234C7D8",
+        "SPDXRef-File--cam-service-src-cam-stream.c-6BE6F090CA5999E487BA9DEB6D0B5E9D2F07BF1F",
+        "SPDXRef-File--cam-service-src-cam-log.c-6BF27E2BE942C4E0317D22B9027A2BF2527C01AB",
+        "SPDXRef-File--cam-service-src-cam-socket.c-FEDEC13E382F96C1DFAB5807A1191B0E20F8806D",
+        "SPDXRef-File--cam-service-test-fixture-84085ddc-bc10-11ed-9a44-7ef9696e9dd6.csd-4D5A978F32A79A23E5A50E3516EF6231F96F977D",
+        "SPDXRef-File--cam-service-test-src-test-suite.c-7D0D164A1D20D1D5AEDC862796C823CB87A07C07",
+        "SPDXRef-File--.git-hooks-update.sample-730E6BD5225478BAB6147B7A62A6E2AE21D40507",
+        "SPDXRef-File--.git-hooks-sendemail-validate.sample-74CF1D5415A5C03C110240F749491297D65C4C98",
+        "SPDXRef-File--.git-objects-pack-pack-dfc8042bd133851dae79f320666964927acd23d6.idx-03F24A13ADDCB1459046EECE9A979EEB157106FC",
+        "SPDXRef-File--.git-description-9635F1B7E12C045212819DD934D809EF07EFA2F4",
+        "SPDXRef-File--cam-uuid-test-src-test-suite.h-30E60F13DCD57065C8F3206914794786E9AEBFFF",
+        "SPDXRef-File--libcam-test-src-test-libcam.c-FA08DEF8E763F31C6890796AE23AE9477940648D",
+        "SPDXRef-File--cam-tool-test-fixture-expected-msg-output-0-42A4902AFCCC45A3244E7E48C58264B267D26275",
+        "SPDXRef-File--cam-tool-test-fixture-success-case.msg-rcv-531873E1E318A30E191041E59F1E926DCB1F375C",
+        "SPDXRef-File--cam-tool-test-fixture-no-meta-uuid.csc.yml-D094E5DF930C9EB40112BDA356567FE2C81F0CBF",
+        "SPDXRef-File--cam-tool-test-fixture-no-padding-bytes.csd-5737DEED8785E47DDAB3BA109B36A3C7B0637700",
+        "SPDXRef-File--cam-tool-test-fixture-valid.csc.yml-2713BBCB038082FB82094E01433F40DABC70BD39",
+        "SPDXRef-File--cam-tool-test---init--.py-99CC0AD65EE34E2C19C7BBE1B2E98783F60C5F26",
+        "SPDXRef-File--cam-tool-cam-tool-cam-csel.py-B744D0E19032DFCD5A818E1CB7D1F26B95BB9D69",
+        "SPDXRef-File--cam-app-example-src-cmdline.c-DD946FF294E3285DB10F38DCAFF0C0DEF2D2C255",
+        "SPDXRef-File--cam-app-example-cam-data-stream2.csc.yml-E9A09C044562B6FB6D37E7E5A5F39235517BEB1F",
+        "SPDXRef-File--scripts-generate-spdx-design-sbom.py-F2A347983DC7A3FDFB9208BCD4766CADF7CCBD05",
+        "SPDXRef-File--cam-service-src-cam-byte-order.h-CFEE563CC5E62DC268996487B4C493D8BE77FF67",
+        "SPDXRef-File--cam-service-src-cam-service.c-123EC5C51BE94C6CA827224150CE9DFB50560D51",
+        "SPDXRef-File--cam-service-test-fixture-84085ddc-bc10-11ed-9a44-7ef9696e9dd0.csd-89E9678D98B0FC0EE2F9E9F767B164D365C8397A",
+        "SPDXRef-File--cam-service-test-src-test-suite.h-CDF9CDBFD5BBE73D030A9DF8D9665C5C35405A62",
+        "SPDXRef-File--.git-hooks-pre-push.sample-A599B773B930CA83DBC3A5C7C13059AC4A6EAEDC",
+        "SPDXRef-File--.git-hooks-commit-msg.sample-EE1ED5AAD98A435F2020B6DE35C173B75D9AFFAC",
+        "SPDXRef-File--.git-hooks-push-to-checkout.sample-508240328C8B55F8157C93C43BF5E291E5D2FBCB",
+        "SPDXRef-File--.git-logs-HEAD-722271669840AAEC922CAABA20363FB2B9193A9B",
+        "SPDXRef-File--cam-uuid-src-cam-uuid.c-5DEC9CB37B34642434C84774014D3C2DEF39F507",
+        "SPDXRef-File--libcam-src-cam.c-59D6C20D06B5D434F1FAD43D5CED2A11A5B9695C",
+        "SPDXRef-File--libcam-CMakeLists.txt-508BCE3E9654DD5D571CB8D90150585862FE2E15",
+        "SPDXRef-File--cam-tool-test-fixture-expected-msg-output-2-43816739F32FD401450F1528759953457B1EFE67",
+        "SPDXRef-File--cam-tool-test-fixture-expected-output.csc-9A700CBED8FE9BC368E0090B1526547434C41276",
+        "SPDXRef-File--cam-tool-test-fixture-empty-file.csc.yml-DA39A3EE5E6B4B0D3255BFEF95601890AFD80709",
+        "SPDXRef-File--cam-tool-test-fixture-expected-msg-output-3-CEC96F2A2E96DCFDD7FDEF02351F15327319943F",
+        "SPDXRef-File--cam-tool-test-test-cam-message.py-B02C92C2EDE06EC43605A4D5F26EF8782C644671",
+        "SPDXRef-File--cam-tool-cam-tool-cam-message.py-AF52202BD621892C4D0C374FCB87EB70F8E3324E",
+        "SPDXRef-File--test-fixture-99085ddc-bc10-11ed-9a44-7ef9696e0000.csc.yml-AEC52C1F0C022CD28C89CE74CD2F58B123CDB5C6",
+        "SPDXRef-File--test-test-config-deploy.py-E9D3FEF98F9501198DCB644A49E68B2323846E22",
+        "SPDXRef-File--.github-workflows-repo-sync.yml-997A90A371BB51F06A898A45B9DFD7243517875E",
+        "SPDXRef-File--.github-workflows-generate-sbom.yml-F3C517A8812682C0A291C44B79135676D4074D16",
+        "SPDXRef-File--docs-screencast-recordings-FVP-Setup-and-terminals-and-commands.mp4-ECA6CB1590899BE0885E03BE85B36B6D8106B4B3",
+        "SPDXRef-File--cam-app-example-src-cmdline.h-5CD15E491354536F4B240848DE00DCD5437330A4",
+        "SPDXRef-File--cam-app-example-cam-data-84085ddc-bc10-11ed-9a44-7ef9696e0000.csd-01653994DA51EE6149B9B5B5968EBD43B1D910D7",
+        "SPDXRef-File--Dockerfiles-README.md-BBB57ECB6744DCEBB9FF2ED57E4517F1A25449E6",
+        "SPDXRef-File--cam-service-src-cam-csd.h-0EA0E9DCC515C3EB174BD53BBA5850C41E15161A",
+        "SPDXRef-File--cam-service-src-cam-service.h-593180CC11784FDA23FDC1B1D87169C53FAD4DFE",
+        "SPDXRef-File--cam-service-test-fixture-84085ddc-bc10-11ed-9a44-7ef9696e9dd5.csd-062A9CDAE020D704F8D4FFE9493B52983CFD23A9",
+        "SPDXRef-File--cam-service-test-src-test-cam-log.c-B3FD6CBC0A39BA5AADAE5814E341E525EE6F1ED6",
+        "SPDXRef-File--.git-refs-remotes-origin-main-51A5D749C236F93BE2E93DFD8D1AA64D4F4069C9",
+        "SPDXRef-File--.git-hooks-prepare-commit-msg.sample-2584806BA147152AE005CB675AA4F01D5D068456",
+        "SPDXRef-File--.git-hooks-post-commit-90E83D48D2E5C47663F21FF5043E31FE56C12278",
+        "SPDXRef-File--.git-logs-refs-remotes-origin-main-676FF629BF28BBA22AF6BDB2ACC069C3188AA2CB",
+        "SPDXRef-File--.git-HEAD-9F1DF7EEA4156BE8A871C292B549B3325E425AA2",
+        "SPDXRef-File--libcam-src-cam-csel.h-63E3FDF626E3EC6B30E49F467EFD152962A448D1",
+        "SPDXRef-File--libcam-include-cam-version.h.in-1A3E9FB08FDACEB2EA734ED61ED9A28F7690AFFD",
+        "SPDXRef-File--cam-tool-test-fixture-expected-output.csd-83CC858D76EC1456512DFFA407E8893E3B3997FF",
+        "SPDXRef-File--cam-tool-test-fixture-invalid-event-alarm-format.csd-9DBB2033B1CB9D7A7BFF6F52902431236248E50A",
+        "SPDXRef-File--cam-tool-test-fixture-no-end-entry.csel-42557B34D8D6DF1B31755F521EC2CE886AB9EC07",
+        "SPDXRef-File--cam-tool-test-fixture-invalid-mode-name.csc.yml-721F11B27E196CFAE16575241E468AD3EDB67EF0",
+        "SPDXRef-File--cam-tool-test-test-cam-csel.py-7735F74E5A53D0CCF8B020CC6676F0B44C6E0E1F",
+        "SPDXRef-File--cam-tool-cam-tool-cam-pack.py-B73CEB94236EB844F3187274186E66BB78742541",
+        "SPDXRef-File--test-fixture-calibration-pack.csc.yml-2E3BED5132B7703A04D82A393AC467EA404A55F5",
+        "SPDXRef-File--test-component.py-67D5218B42DDBEAA911052EF0F5DB3F98A999C5D",
+        "SPDXRef-File--.github-workflows-build-reusable-workflow.yaml-2B82A21138E22A49A4974C77CC72148502811D37",
+        "SPDXRef-File--.github-workflows-Kronos.yaml-93C30B82E49670E235C9947A73DE21546C57C382",
+        "SPDXRef-File--docs-screencast-recordings-TMUX-and-Installation.mp4-94759FDB0D2B2BDC81A54177857B633B58ECF40A",
+        "SPDXRef-File--.git-shallow-51A5D749C236F93BE2E93DFD8D1AA64D4F4069C9",
+        "SPDXRef-File--cam-uuid-test-src-test-suite.c-A29C11054F5F209D10963CEDB0018D9D561AE899",
+        "SPDXRef-File--libcam-test-src-test-suite.h-30E60F13DCD57065C8F3206914794786E9AEBFFF",
+        "SPDXRef-File--cam-tool-test-fixture-no-meta.csc.yml-51A03E2DD226DE200EAB9B90FD5D85A9CB0BC05A",
+        "SPDXRef-File--cam-tool-test-fixture-no-padding-bytes.csel-6022672C7971BE526F9CBB4B7FD4E6F3467DCF04",
+        "SPDXRef-File--cam-tool-test-fixture-invalid-command-id.msg-rcv-6892044A8100A5425A569EB2127A53914DBED544",
+        "SPDXRef-File--cam-tool-test-fixture-invalid-entry-type.csel-47CEA57F0303B2C20AC64884262A907A1B832263",
+        "SPDXRef-File--cam-tool-test-fixture-inconsistent-uuid.msg-rcv-F51A3E3AA4A405B281EE23C4A5DA4BACBE64C8D5",
+        "SPDXRef-File--cam-tool-test-test-cam-csd.py-A8EF645A845E0671A682E6EAA816F20728914CC4",
+        "SPDXRef-File--cam-tool-cam-tool-cam-analyze.py-B7F2804A15B69FE382C7D56ED940C4691B7846BB",
+        "SPDXRef-File--cam-app-example-cam-data-stream3.csc.yml-CAF7B6B3E42354802A33581855DD5EBE8B0FF855",
+        "SPDXRef-File--cam-service-src-cam-socket.h-DB7379FF8E36074013239786061C8128A9F12175",
+        "SPDXRef-File--cam-service-src-cam-config.c-A33EF64845B1C4765FAF99DB96CB96A4CCA9DD2E",
+        "SPDXRef-File--cam-service-test-fixture-84085ddc-bc10-11ed-9a44-7ef9696e9dd4.csd-93CEBCFF20A0D6BD76387C9B31399335CA1753CF",
+        "SPDXRef-File--cam-service-test-src-posix-call-utils.h-5A708BD5310DBEECE6A6080441282457718E7B05",
+        "SPDXRef-File--cam-service-common-cam-message.h-5A3730C811AD621A212740FD29F45B63EA8C64AD",
+        "SPDXRef-File--.git-hooks-pre-rebase.sample-288EFDC0027DB4CFD8B7C47C4AEDDBA09B6DED12",
+        "SPDXRef-File--.git-hooks-pre-applypatch.sample-F208287C1A92525DE9F5462E905A9D31DE1E2D75",
+        "SPDXRef-File--.git-objects-pack-pack-dfc8042bd133851dae79f320666964927acd23d6.rev-ECEAA6B4884DFD9AA92D685139B6DE50C315A24A",
+        "SPDXRef-File--.git-config.worktree-CA859A5B32728E6B456D4E5011D9011BB638AC1C",
+        "SPDXRef-File--cam-uuid-test-CMakeLists.txt-73529D565EAB077BE2941022E5A881541529D7F0",
+        "SPDXRef-File--libcam-test-src-test-suite.c-A1AF64B2AAEF31D7E5E03BC1A17A7EF16465A838",
+        "SPDXRef-File--cam-tool-test-fixture-unexpected-status-type.msg-rcv-C4E1A68A47741430037C51F1CADD5E2F80DEBBE3",
+        "SPDXRef-File--cam-tool-test-fixture-file-size-overflow.csd-70F9465FE4A5A7C41EACF00DAC3B9F61002C519C",
+        "SPDXRef-File--cam-tool-test-fixture-invalid-version.csc.yml-08BA3ADE3C14F15129F6165C47C429BE76674946",
+        "SPDXRef-File--cam-tool-test-fixture-no-version.csc.yml-64AF7B974DCB6CD16359FD34F6DA3A7B598FA0D2",
+        "SPDXRef-File--cam-tool-test-fixture-invalid-timeout.csc.yml-F29793EED18438DC1BFD6B3D3356FAA3B951657B",
+        "SPDXRef-File--cam-tool-cam-tool-cam-deploy.py-5098F7AA4441CBEB1D52C9F017999C43C6D055A8",
+        "SPDXRef-File--cam-tool-cam-tool-cam-csd.py-6227BB362E49D0D96E6610527B3A5299CE7F4766",
+        "SPDXRef-File--test-fixture-config-deploy-valid.csd-83CC858D76EC1456512DFFA407E8893E3B3997FF",
+        "SPDXRef-File--test-test-calibration.py-C89FCFA1CE881D2D7D1263C88C3A962D2DAF91D1",
+        "SPDXRef-File--.github-workflows-sbom-exper2.yml-E3562936495B7045E97B5BE23FFCC104EB1C9484",
+        "SPDXRef-File--.github-workflows-mainSBOMgen.yml-55DD4509FCC09AE090C0256FC0E829B8631DEC5F",
+        "SPDXRef-File--docs-strictdoc-evidence-EVID-009-csel-generation-and-analysis.txt-7B73F07346B04D25D4A18C4B1B780A0876D93492",
+        "SPDXRef-File--docs-strictdoc-evidence-EVID-011-protocol-header-handler-validation.txt-52CDDC675EC716E1D497915CB01CE0026506D515",
+        "SPDXRef-File--docs-strictdoc-09-trace-matrix.sdoc-B386FDCE09A2F51191FC15DDD0DFA1B4A330F1D0",
+        "SPDXRef-File--docs-strictdoc-README.md-29F540525AF57E8F3C885362231B0F5D98FC42FD",
+        "SPDXRef-File--docs-demos-README.md-6C5F2B7281974392451115F37581C6F9A4FDFEAD",
+        "SPDXRef-File--documentation-images-cam-components.svg-48EB74708336D066955B4810FCF33C5E8D356B43",
+        "SPDXRef-File--documentation-development-index.rst-F31BE237B430E33F3346DAE9C5E7D8CB6A5C608D",
+        "SPDXRef-File--documentation-CMakeLists.txt-2B74A3223044E50C4AAC16EC4AA4DBCA34EED324",
+        "SPDXRef-File--Dangerfile-0FF0B87CC10146DEA17C795E40C60B7A2B33AEF6",
+        "SPDXRef-File--test-fixture-99085ddc-bc10-11ed-9a44-7ef9696e0000.csd-8CAD6A0C5B6F171CF8F0AF0BE03FB2070C8CD7C0",
+        "SPDXRef-File--.github-workflows-correlium.yaml-E233632E89F7F03755E9D2F8A4B16317E65B9AAE",
+        "SPDXRef-File--.github-workflows-safety-docs.yml-02CE9D355E7785FF72EE0E8414A6DB926C0B189B",
+        "SPDXRef-File--.github-workflows-super-linter.yaml-A4D9459C3877B00E6FA98054D10250ADA592E960",
+        "SPDXRef-File--docs-strictdoc-evidence-EVID-012-ci-sbom-artifact.txt-BE4E7E0B040AE85FA02914991445D29B27537383",
+        "SPDXRef-File--docs-strictdoc-evidence-EVID-004-start-to-first-event-timeout.txt-50BDFB19E32CA59800505F1C60530B506A4F5264",
+        "SPDXRef-File--docs-strictdoc-EXPORT-INSTRUCTIONS.md-2501658D15C120630C7832F07E05942BD02F9A92",
+        "SPDXRef-File--docs-strictdoc-08-evidence-log.sdoc-C7EAE589EDA66EF750173C9EE3219B1351A89694",
+        "SPDXRef-File--docs-demos-project-gearshift-demo-scenario-copilot.md-DADE9124CCA3B182500FEDF4E21045D3F2D37092",
+        "SPDXRef-File--documentation-manual-index.rst-6000F7F3027086ED04B6D2CE5B649AE2A0CE8DDE",
+        "SPDXRef-File--documentation-development-validation.rst-8F4D47C8A2CE2C2A31B1463FD36C344533BA1426",
+        "SPDXRef-File--documentation-doxyfile.in-53C725FA349593DE2980031FF464EB191702DB64",
+        "SPDXRef-File--.DS-Store-4B84BEED4F4ACC6F98DCAF193C0A2BB05F533D9A",
+        "SPDXRef-File--cam-tool-pyproject.toml-69538DF8B7CA45392165C8DE6931B98B5451BEDB",
+        "SPDXRef-File--test-fixture-config-deploy-invalid.csd-3329494445A06C421C84B682F60CF28FEF665F5A",
+        "SPDXRef-File--.github-workflows-build-cam-app.yaml-45AD4A5CE3AA967FBCBFE79CF8ACCFBE1031020B",
+        "SPDXRef-File--.github-workflows-code-coverage.yaml-96397A8E74EE740B15453C4EDF094515B5BF8CBD",
+        "SPDXRef-File--.github-dependabot.yml-3D2B68A042CA883BE6F12D33A24FABD3931FBC73",
+        "SPDXRef-File--docs-strictdoc-evidence-EVID-005-event-before-start-fault.txt-F738A8DB8ECFF9C604D31E2A783B2DFC48494F54",
+        "SPDXRef-File--docs-strictdoc-evidence-EVID-003-sequence-mismatch-fault.txt-7ACA608B64600100B9F5F53AB750912C0D34CC58",
+        "SPDXRef-File--docs-strictdoc-strictdoc.toml-57DD715261F13F14197A237D5C44C21C35268147",
+        "SPDXRef-File--docs-strictdoc-00-item-definition.sdoc-B33028A11A42301C6E384B008EA93DAE78DB29B9",
+        "SPDXRef-File--docs-.DS-Store-3FDBB98C715247247D3549E4E622E97F29C6E369",
+        "SPDXRef-File--documentation-manual-libcam-api.rst-02E25925E274224DB87DBA00762F95D86D3F72F5",
+        "SPDXRef-File--documentation-development-coding-style.rst-695E8BCBC4E82D3C403A30B9C2F409DFB8BB6FA3",
+        "SPDXRef-File--documentation-getting-started.rst-65E3C81C64BFD1C2E85F65DCBE06B47D76BB987C",
+        "SPDXRef-File--.gitmodules-2D3388FE54BDC635318EE07D60AD92DC4FAFCDA4",
+        "SPDXRef-File--docs-strictdoc-evidence-EVID-006-csc-validation-and-conversion.txt-D554A42A6064AAEAEC0441B452440D93314A97CF",
+        "SPDXRef-File--docs-strictdoc-05-swa-cam.sdoc-9F15A3AA7EEB2F99FD3A031DB26DA9C2D89E4870",
+        "SPDXRef-File--docs-strictdoc-04-ssr-cam.sdoc-EE9983D01C412C9F73925C799C391C2920003330",
+        "SPDXRef-File--docs-demos-cicd.png-1CC22BC2C252E9668F878003ACD10A0204CCA471",
+        "SPDXRef-File--documentation-images-event-interval.svg-121EC6E3C791FDF92DF651A84CAC062D0C328466",
+        "SPDXRef-File--documentation-manual-file-csd.rst-BEF0A366BD190B3C9987FE6596FCCFBB3879EB3B",
+        "SPDXRef-File--documentation-index.rst-60ED03295AA86DCA8A81B1FC8A03973B0D59ED09",
+        "SPDXRef-File--Kconfig-F465C8DC8C1F3062054BE5523F07B9EC3E6851D8",
+        "SPDXRef-File--.gitattributes-B6143C97D3D1DD843B6D533BD4847C1A81E2D756",
+        "SPDXRef-File--docs-strictdoc-evidence-EVID-002-out-of-order-event-detection.txt-F6D6BB3A3BD6BC9CC5495DBB440866A482517F37",
+        "SPDXRef-File--docs-strictdoc-07-test-specs.sdoc-801B381EADC023B6227BFA3A4E0CCAD2C9C9DCC0",
+        "SPDXRef-File--docs-strictdoc-03-tsc-lite.sdoc-0A6007ADC4AD1CD912F4A51887D411536CA3AAE6",
+        "SPDXRef-File--docs-demos-IntegrationDoc.md-9253A9105C5600331DA5F412467EBC68670DB799",
+        "SPDXRef-File--documentation-images-cam-timings.svg-212AEA7CE6959DCD5A9AD861693FA86FDA5862B0",
+        "SPDXRef-File--documentation-manual-message-protocol.rst-81BF4DD1113F1BFA114B3C24F487C25EC1DE411A",
+        "SPDXRef-File--documentation-conf.py-032B36C380275C8ECE8607D9A1D01E7196A799A9",
+        "SPDXRef-File--prj.conf-06A4F39165FD4E56763CA2FCA64B0EF8954C3CE1",
+        "SPDXRef-File--kas-build.yml-B429194A86D4E5BBFD6713A8BF982A09643196A8",
+        "SPDXRef-File--test-fixture-calibration-analyze.csel-3329494445A06C421C84B682F60CF28FEF665F5A",
+        "SPDXRef-File--test-test-static-config.py-47FF9981FC9B1718C94E13C3E0E5C15DAA0F6549",
+        "SPDXRef-File--.github-workflows-kas-auto-build.yml-BCA65F4579DB4B6424E88E7184147451015AC94C",
+        "SPDXRef-File--.github-workflows-strictdoc-export.yml-28E30D129435BE2720AE8698E0AA1DE260374E8A",
+        "SPDXRef-File--docs-screencast-recordings-Introduction-Navigation-Recording.mp4-31986C4CDE5C1618B869675195AD67EEB5B4D378",
+        "SPDXRef-File--docs-strictdoc-evidence-EVID-008-future-timestamp-rejection.txt-708DA0856E63041F222573088402A4DD2430FBF1",
+        "SPDXRef-File--docs-strictdoc-06-verification-plan.sdoc-222C8219081AA7FABFCC5A004DB677153080A619",
+        "SPDXRef-File--docs-strictdoc-01-hara-lite.sdoc-60AD39D89246C86E24477722959BBC06363F7E16",
+        "SPDXRef-File--docs-demos-project-gearshift-demo-scenario-appsecurity-ghas.md-627EFF5DA7CBFC54615C036115E32798FF5FFD26",
+        "SPDXRef-File--documentation-images-cam-overview.svg-43A589CA729079E8A986BA477D6CA04B230B775C",
+        "SPDXRef-File--documentation-manual-file-csel.rst-F549E6C548D67CC78320C480B3C2201233026374",
+        "SPDXRef-File--documentation-overview.rst-58549620111F13EF590623AF4C84BB521818DAEA",
+        "SPDXRef-File--.dictionary-291994BFD92EAE2A2BA5C7A0269B3F98E2909142",
+        "SPDXRef-File--license.rst-D9C974B17783DCD346D897432773DD17C231E26A",
+        "SPDXRef-File--SECURITY.md-FA533283215D0BA141A7A28AC0D4FDC8089E3F0B",
+        "SPDXRef-File--cam-app-example-cam-data-84085ddc-bc10-11ed-9a44-7ef9696e0001.csd-CA32F5D6E9EE31C51FD93739834F7FF67E0AAA93",
+        "SPDXRef-File--cam-app-example-CMakeLists.txt-7CE727E657055E814EA31C91E9C3C4D8525129EB",
+        "SPDXRef-File--cam-service-src-cam-config.h-983C9B066BDEDEF0B10DF31CCB8B390CC0D5B0A5",
+        "SPDXRef-File--cam-service-src-cam-stream.h-07CC268E59C3E5286D0EEF70E55D50D18B40B82E",
+        "SPDXRef-File--cam-service-test-fixture-84085ddc-bc10-11ed-9a44-7ef9696e9dd7.csd-CBE5C5E17960713783A419D122433B548A78E933",
+        "SPDXRef-File--cam-service-test-src-test-cam-socket.c-DC3E53359233F8D64E9717A909A03EFC9307CC92",
+        "SPDXRef-File--cam-service-test-CMakeLists.txt-6EF2225B24DA4CCBA84F68EA89D96503E208C29D",
+        "SPDXRef-File--.git-hooks-pre-merge-commit.sample-04C64E58BC25C149482ED45DBD79E40EFFB89EB7",
+        "SPDXRef-File--.git-hooks-post-update.sample-B614C2F63DA7DCA9F1DB2E7ADE61EF30448FC96C",
+        "SPDXRef-File--test-fixture-99085ddc-bc10-11ed-9a44-7ef9696e0001.csd-DECB406C982A00276FA967201C9B8331FBB8C8B6",
+        "SPDXRef-File--test-conftest.py-1CAFCFB361A995F4D9A342D260548E9F184C211D",
+        "SPDXRef-File--.github-workflows-Kronos-Latest.yaml-5637276E7856B01BF8E43E24F916D6B16E65356B",
+        "SPDXRef-File--.github-workflows-automated-kas-setup.yml-13233442371BD36EEFAB2CFC0DD53DEE3591EA34",
+        "SPDXRef-File--docs-screencast-recordings-CAMDemo-Automation-results.mp4-03D57D5CE2FC70D330C1757A0CEFFB1C9924E3FB",
+        "SPDXRef-File--docs-strictdoc-evidence-EVID-001-temporal-fault-detection.txt-1375D89BF1BF435171B2EAE4334E24781601E5BB",
+        "SPDXRef-File--docs-strictdoc-demo-script.md-A409B1CA88D6E07E575411B260D4BE6BBAD680A8",
+        "SPDXRef-File--docs-strictdoc-cam-fusa.sgra-F51F528801ACABD35CD92B4B2824F6419FCF78B6",
+        "SPDXRef-File--docs-demos-project-gearshift-demo-scenario-unittests.md-2048CB17747D80661512FEF0560836E15259387E",
+        "SPDXRef-File--documentation-images-fault-injection.svg-85911D560DBF135B6635C5E669BB6A0571E69398",
+        "SPDXRef-File--documentation--static-css-custom.css-24A745E0C2B3A8C5DEBD4340571F895AAC3A96F2",
+        "SPDXRef-File--documentation-release-notes.rst-828594325069BC7100CB59B7413DA26D7190CD15",
+        "SPDXRef-File--.gitignore-8A015813F7BDBDBB99B4286A32A03D41F2F803BF",
+        "SPDXRef-File--CMakeLists.txt-35A4BFDCBEAC91A1CA69AE2971DD7742A3341EE0",
+        "SPDXRef-File--test-fixture-99085ddc-bc10-11ed-9a44-7ef9696e0001.csc.yml-66A179E3CC4CA4E7A972F77C65988C623B4FB208",
+        "SPDXRef-File--test-fixture-calibration-invalid-analyze.csel-678DCFAE77E7B59A602C5B755A6028A01BAF9627",
+        "SPDXRef-File--.github-workflows-corellium-saas.yaml-2331229D101363C470F8F1EAE01639C27D709AC7",
+        "SPDXRef-File--.github-workflows-build-cam-app-exper.yml-92C4B65CEA547955179D00C1E31DC235ED7D971E",
+        "SPDXRef-File--docs-screencast-recordings-ScreencastUpdated.mp4-5A1C1A319126ED0718432FC79534069491EBBDA3",
+        "SPDXRef-File--docs-strictdoc-evidence-EVID-010-libcam-protocol-sequence.txt-EA033D404B5307566EF0D8C3CC6609D742428803",
+        "SPDXRef-File--docs-strictdoc-evidence-EVID-007-deploy-message-chunking.txt-7B87AFED92003513E09735899EBE88E7B795D704",
+        "SPDXRef-File--docs-strictdoc-02-fsc-lite.sdoc-441C5B9C5D87EF26CED32BC31FFDC5EECB6D5015",
+        "SPDXRef-File--docs-demos-project-gearshift-demo-scenario-integrationtests.md-96ABDE387BBCF05CED314CA2BB066EADB5D2E275",
+        "SPDXRef-File--documentation-cmake-FindSPHINX.cmake-523D03A6BBE1572A7935FFBC0473978AD99CE48A",
+        "SPDXRef-File--documentation-manual-file-csc.rst-A2DD41175AABDAD3A7D86428A646B514ACF6A927",
+        "SPDXRef-File--documentation-license-link.rst-6E2E46EF9CA8EF0F8BBC0A3011BF6DF1B6578277",
+        "SPDXRef-File--.codeclimate.yml-B2CEE30FD5E2C2BB525F0019546094B4F2C6921A",
+        "SPDXRef-File--.readthedocs.yaml-71E0A36B7643334D48EAD0A3C865120841629A5C",
+        "SPDXRef-File--.clang-format-6B5CD29FB1194B199BF9F6C37BF9234CF43E63C6",
+        "SPDXRef-File--requirements.txt-92F50CBE2B01F83F6A3E25BDDF2CEBEFF743A0E0",
+        "SPDXRef-File--README.md-A3163A0CAC9F443EDF625648EFE70C3D365E6CDB"
+      ]
+    }
+  ],
+  "externalDocumentRefs": [],
+  "relationships": [
+    {
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-RootPackage",
+      "spdxElementId": "SPDXRef-DOCUMENT"
+    },
+    {
+      "relationshipType": "DEPENDS_ON",
+      "relatedSpdxElement": "SPDXRef-Package-480871C937AB17B2CA00697B94806F3B668E9C726D662774832FD26A33E9C973",
+      "spdxElementId": "SPDXRef-RootPackage"
+    },
+    {
+      "relationshipType": "DEPENDS_ON",
+      "relatedSpdxElement": "SPDXRef-Package-997BB0F681869CA98D5667676CD5B68622673C2FEF7DC8A74C4063DC206A7218",
+      "spdxElementId": "SPDXRef-RootPackage"
+    },
+    {
+      "relationshipType": "DEPENDS_ON",
+      "relatedSpdxElement": "SPDXRef-Package-F891BD098C2683819984852B8A47264307A6F37C7CB948CEA205390A27FED40D",
+      "spdxElementId": "SPDXRef-RootPackage"
+    },
+    {
+      "relationshipType": "DEPENDS_ON",
+      "relatedSpdxElement": "SPDXRef-Package-25A88B0E02EA9C9A3AF567240D2E9383B7A0B6C2B0D847431A58F42A9C2D6779",
+      "spdxElementId": "SPDXRef-RootPackage"
+    },
+    {
+      "relationshipType": "DEPENDS_ON",
+      "relatedSpdxElement": "SPDXRef-Package-501BDE8C2898B8F7C7CE89A8E40E4EE4137C22696CD458B85DDC6F4C505B5C05",
+      "spdxElementId": "SPDXRef-RootPackage"
+    },
+    {
+      "relationshipType": "DEPENDS_ON",
+      "relatedSpdxElement": "SPDXRef-Package-3F012714C432ACDFE4FC4261380361E90457B9E6DA4933C8205A749D16624AD3",
+      "spdxElementId": "SPDXRef-RootPackage"
+    },
+    {
+      "relationshipType": "DEPENDS_ON",
+      "relatedSpdxElement": "SPDXRef-Package-608734958F785BCA948551853649C7FC98B52E5D2060EC426F90714C5A70228D",
+      "spdxElementId": "SPDXRef-RootPackage"
+    },
+    {
+      "relationshipType": "DEPENDS_ON",
+      "relatedSpdxElement": "SPDXRef-Package-4DEA190FC8CE8EE0F406A9FF1F755BA738B18B7A986FF9D7E7F3731248E81E75",
+      "spdxElementId": "SPDXRef-RootPackage"
+    },
+    {
+      "relationshipType": "DEPENDS_ON",
+      "relatedSpdxElement": "SPDXRef-Package-C99E2E1E6C0E9A26D42002AD18B5C4EC3DD2F09BF57BDC6A772477CFBC5B33D1",
+      "spdxElementId": "SPDXRef-RootPackage"
+    },
+    {
+      "relationshipType": "DEPENDS_ON",
+      "relatedSpdxElement": "SPDXRef-Package-87749F3F5444B22B14A14E3607A49BA23BCDAEDF24C51964277B625FD9FD4967",
+      "spdxElementId": "SPDXRef-RootPackage"
+    }
+  ],
+  "spdxVersion": "SPDX-2.2",
+  "dataLicense": "CC0-1.0",
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "name": "im-customers-arm/arm-critical-app-monitoring 1.0.0",
+  "documentNamespace": "https://sbom.infomagnus.com/im-customers-arm%2Farm-critical-app-monitoring/1.0.0/T89QZ2o_NEKuW9ZehHU9MQ",
+  "creationInfo": {
+    "created": "2026-02-18T02:26:12Z",
+    "creators": [
+      "Organization: OwnerName",
+      "Tool: Microsoft.SBOMTool-4.1.5"
+    ]
+  },
+  "documentDescribes": [
+    "SPDXRef-RootPackage"
+  ]
+}

--- a/testResources/spdx2tospdx3conversion/source-conversion2-spdx2.json.json
+++ b/testResources/spdx2tospdx3conversion/source-conversion2-spdx2.json.json
@@ -1,0 +1,5685 @@
+{
+  "files": [
+    {
+      "fileName": "./SECURITY.md",
+      "SPDXID": "SPDXRef-File--SECURITY.md-FA533283215D0BA141A7A28AC0D4FDC8089E3F0B",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ba9643955bfcb04524a6fe5a8c2929b54abc2e67bb3480ce806e742d506e4dc9"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "fa533283215d0ba141a7a28ac0d4fdc8089e3f0b"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.gitmodules",
+      "SPDXID": "SPDXRef-File--.gitmodules-2D3388FE54BDC635318EE07D60AD92DC4FAFCDA4",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "f4170934898bc41c156c3122f88cb1945b250c14e8f67788384baa2a58391687"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "2d3388fe54bdc635318ee07d60ad92dc4fafcda4"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./documentation/getting_started.rst",
+      "SPDXID": "SPDXRef-File--documentation-getting-started.rst-65E3C81C64BFD1C2E85F65DCBE06B47D76BB987C",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "4cebeb5de24398fde4460c4f3f597391dc9e22041a361ec1a994ca6a76628ac6"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "65e3c81c64bfd1c2e85f65dcbe06b47d76bb987c"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./documentation/development/coding_style.rst",
+      "SPDXID": "SPDXRef-File--documentation-development-coding-style.rst-695E8BCBC4E82D3C403A30B9C2F409DFB8BB6FA3",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "1ca26c79dcd52cb3bf06157b0127b695301742c71363e95266ae40a2c27797a9"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "695e8bcbc4e82d3c403a30b9c2f409dfb8bb6fa3"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./CMakeLists.txt",
+      "SPDXID": "SPDXRef-File--CMakeLists.txt-35A4BFDCBEAC91A1CA69AE2971DD7742A3341EE0",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "c35c0919aa86c23df3bbeedcb9ec0f23b821f088fba5806b00c2b74c6749e481"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "35a4bfdcbeac91a1ca69ae2971dd7742a3341ee0"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.gitignore",
+      "SPDXID": "SPDXRef-File--.gitignore-8A015813F7BDBDBB99B4286A32A03D41F2F803BF",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "a76e2548a45d5140d2c69f73d31852f79244dac1c4f3d7458762a877a100baab"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "8a015813f7bdbdbb99b4286a32a03d41f2f803bf"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./documentation/release_notes.rst",
+      "SPDXID": "SPDXRef-File--documentation-release-notes.rst-828594325069BC7100CB59B7413DA26D7190CD15",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "cb23441bc84fce44945aee983417fb1f3802d1ab796d9c7b164ec3807dccb33f"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "828594325069bc7100cb59b7413da26d7190cd15"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./documentation/_static/css/custom.css",
+      "SPDXID": "SPDXRef-File--documentation--static-css-custom.css-24A745E0C2B3A8C5DEBD4340571F895AAC3A96F2",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "d18fc2d6d8615e8cb1486068b26535e7f6ba46b523d1896bfc1c98c711ea76d5"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "24a745e0c2b3a8c5debd4340571f895aac3a96f2"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./license.rst",
+      "SPDXID": "SPDXRef-File--license.rst-D9C974B17783DCD346D897432773DD17C231E26A",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "7bf2c6e1b50a20702e79ef3905bdcd1f11db5dd06577f2129e69e977540f63bd"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "d9c974b17783dcd346d897432773dd17c231e26a"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.dictionary",
+      "SPDXID": "SPDXRef-File--.dictionary-291994BFD92EAE2A2BA5C7A0269B3F98E2909142",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "dca1577e648590f704138af77f5676e20401dbb3583db02f42c855b4460215e2"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "291994bfd92eae2a2ba5c7a0269b3f98e2909142"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./documentation/overview.rst",
+      "SPDXID": "SPDXRef-File--documentation-overview.rst-58549620111F13EF590623AF4C84BB521818DAEA",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "5aff32931ff67dc147f13c77bdab9ac3ae4a511a5b0a213ff42daf3d0d7e5c7e"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "58549620111f13ef590623af4c84bb521818daea"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./kas-build.yml",
+      "SPDXID": "SPDXRef-File--kas-build.yml-B429194A86D4E5BBFD6713A8BF982A09643196A8",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "8709ca06ad8d6d1f27bf23ca3c533c5a162deb5797920b0e79f61434c6da5a5f"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b429194a86d4e5bbfd6713a8bf982a09643196a8"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./prj.conf",
+      "SPDXID": "SPDXRef-File--prj.conf-06A4F39165FD4E56763CA2FCA64B0EF8954C3CE1",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "4246383542c78173c37081b565b7b07a70757ee50198882dd7445c5fddd3dda4"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "06a4f39165fd4e56763ca2fca64b0ef8954c3ce1"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./documentation/conf.py",
+      "SPDXID": "SPDXRef-File--documentation-conf.py-032B36C380275C8ECE8607D9A1D01E7196A799A9",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "e556feb5583ce2db454b30cb33eb7b6c78021a7c4699717f80850cad63165935"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "032b36c380275c8ece8607d9a1d01e7196a799a9"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.gitattributes",
+      "SPDXID": "SPDXRef-File--.gitattributes-B6143C97D3D1DD843B6D533BD4847C1A81E2D756",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "bfe2e7093f352205764534b2fc590dd92addf7e46dc6e29e66e6701706a9e581"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b6143c97d3d1dd843b6d533bd4847c1a81e2d756"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./Kconfig",
+      "SPDXID": "SPDXRef-File--Kconfig-F465C8DC8C1F3062054BE5523F07B9EC3E6851D8",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "c18cd5a072d322e940500a1ce579469675d6bf70e0928fac971649933a328671"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "f465c8dc8c1f3062054be5523f07b9ec3e6851d8"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./documentation/index.rst",
+      "SPDXID": "SPDXRef-File--documentation-index.rst-60ED03295AA86DCA8A81B1FC8A03973B0D59ED09",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "1244b1f142c042ff74a0a1e3bb622f6047d4fd1d50f4518588abeb7fe2b6d85e"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "60ed03295aa86dca8a81b1fc8a03973b0d59ed09"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./README.md",
+      "SPDXID": "SPDXRef-File--README.md-A3163A0CAC9F443EDF625648EFE70C3D365E6CDB",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "bf1f0422f17c7d5a3007d3f78b79408545615b335dd4b19b75ffde0f644657fa"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "a3163a0cac9f443edf625648efe70c3d365e6cdb"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.DS_Store",
+      "SPDXID": "SPDXRef-File--.DS-Store-4B84BEED4F4ACC6F98DCAF193C0A2BB05F533D9A",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "6558814771674110a74a7012daa0414b3b7c25d1541405d843c5a4d1409829d0"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "4b84beed4f4acc6f98dcaf193c0a2bb05f533d9a"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./documentation/doxyfile.in",
+      "SPDXID": "SPDXRef-File--documentation-doxyfile.in-53C725FA349593DE2980031FF464EB191702DB64",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "9943f9a3e672c835e923e5de6abeeadad4fd4bb310870379f5fce1c366179677"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "53c725fa349593de2980031ff464eb191702db64"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./documentation/development/validation.rst",
+      "SPDXID": "SPDXRef-File--documentation-development-validation.rst-8F4D47C8A2CE2C2A31B1463FD36C344533BA1426",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "da4835c98d121ba4dec463d0fff9b1787b9cd2c22dc50a0d68575153e010ef95"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "8f4d47c8a2ce2c2a31b1463fd36c344533ba1426"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./requirements.txt",
+      "SPDXID": "SPDXRef-File--requirements.txt-92F50CBE2B01F83F6A3E25BDDF2CEBEFF743A0E0",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "b251603e2d912b5b9ae8c8beafcdc0322df50d1e91ec5debd02661d02cd3b870"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "92f50cbe2b01f83f6a3e25bddf2cebeff743a0e0"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./Dangerfile",
+      "SPDXID": "SPDXRef-File--Dangerfile-0FF0B87CC10146DEA17C795E40C60B7A2B33AEF6",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "4e90bc4b377f6dc175867d01e226774ec84fe7664dc2040139af130561b7c4d4"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "0ff0b87cc10146dea17c795e40c60b7a2b33aef6"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./documentation/CMakeLists.txt",
+      "SPDXID": "SPDXRef-File--documentation-CMakeLists.txt-2B74A3223044E50C4AAC16EC4AA4DBCA34EED324",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "d2260d1ff1cee4bea7c5b8933b02f010428bb88e0e78e0a33535d20ffd4e3ad0"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "2b74a3223044e50c4aac16ec4aa4dbca34eed324"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./documentation/development/index.rst",
+      "SPDXID": "SPDXRef-File--documentation-development-index.rst-F31BE237B430E33F3346DAE9C5E7D8CB6A5C608D",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "5de179e3d0a750686a34f0fa45cbe49b439e90f05e3808889005313421460a4c"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "f31be237b430e33f3346dae9c5e7d8cb6a5c608d"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./documentation/images/cam_components.svg",
+      "SPDXID": "SPDXRef-File--documentation-images-cam-components.svg-48EB74708336D066955B4810FCF33C5E8D356B43",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "4eafcfa6458739814d412dd819566d5e3b741fa2bca4b5f918e62a583094d0fa"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "48eb74708336d066955b4810fcf33c5e8d356b43"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/demos/README.md",
+      "SPDXID": "SPDXRef-File--docs-demos-README.md-6C5F2B7281974392451115F37581C6F9A4FDFEAD",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "0db1b1e858c0dcc08fc04debaa8100fc9f061115a292d7e85f56acbcb9c92d5d"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6c5f2b7281974392451115f37581c6f9a4fdfead"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/strictdoc/README.md",
+      "SPDXID": "SPDXRef-File--docs-strictdoc-README.md-29F540525AF57E8F3C885362231B0F5D98FC42FD",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "beafa75d380b164edc2ce391c4449e22e9def35b94cbdf1679ce207119629d5a"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "29f540525af57e8f3c885362231b0f5d98fc42fd"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/strictdoc/09_trace_matrix.sdoc",
+      "SPDXID": "SPDXRef-File--docs-strictdoc-09-trace-matrix.sdoc-B386FDCE09A2F51191FC15DDD0DFA1B4A330F1D0",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ef59a9012b902c4e17df494a14f65e95c26a4554480c3d3351fe41501ec16bc4"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b386fdce09a2f51191fc15ddd0dfa1b4a330f1d0"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/strictdoc/evidence/EVID-011-protocol-header-handler-validation.txt",
+      "SPDXID": "SPDXRef-File--docs-strictdoc-evidence-EVID-011-protocol-header-handler-validation.txt-52CDDC675EC716E1D497915CB01CE0026506D515",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "0629c2bb09315f6109c09318586711163a497564f44fd844a35fec6e3d5bc86f"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "52cddc675ec716e1d497915cb01ce0026506d515"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/strictdoc/evidence/EVID-009-csel-generation-and-analysis.txt",
+      "SPDXID": "SPDXRef-File--docs-strictdoc-evidence-EVID-009-csel-generation-and-analysis.txt-7B73F07346B04D25D4A18C4B1B780A0876D93492",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "3e5eb5676fba7911ad5b23796ae67112b30dba0216cacdf14dcc0957cb48036e"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "7b73f07346b04d25d4a18c4b1b780a0876d93492"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.github/workflows/mainSBOMgen.yml",
+      "SPDXID": "SPDXRef-File--.github-workflows-mainSBOMgen.yml-F0B7428A33CE80BE3FA3A2A8DB4FC5E847829350",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "b7739cce27873ef843fc26672f1f8a63d541f13d48cf01a1de6b4416b636ed8d"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "f0b7428a33ce80be3fa3a2a8db4fc5e847829350"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.github/workflows/Kronos-Latest.yaml",
+      "SPDXID": "SPDXRef-File--.github-workflows-Kronos-Latest.yaml-5637276E7856B01BF8E43E24F916D6B16E65356B",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "282bff12556c58ea1f3d36048bdc9e7978936f53493a62603cdee89fb95fac37"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "5637276e7856b01bf8e43e24f916d6b16e65356b"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./test/conftest.py",
+      "SPDXID": "SPDXRef-File--test-conftest.py-1CAFCFB361A995F4D9A342D260548E9F184C211D",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "2a88cc56d42d0ff65239d822ddedb35b947c4db8c4c3439ff33d9c551d6bf774"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "1cafcfb361a995f4d9a342d260548e9f184c211d"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./test/fixture/99085ddc-bc10-11ed-9a44-7ef9696e0001.csd",
+      "SPDXID": "SPDXRef-File--test-fixture-99085ddc-bc10-11ed-9a44-7ef9696e0001.csd-DECB406C982A00276FA967201C9B8331FBB8C8B6",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "915d26f3c6a9bce19ccb2a1d5c138f5856f5eaadef1215d4f408d5818438ce1d"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "decb406c982a00276fa967201c9b8331fbb8c8b6"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/cam_tool/cam_csel.py",
+      "SPDXID": "SPDXRef-File--cam-tool-cam-tool-cam-csel.py-B744D0E19032DFCD5A818E1CB7D1F26B95BB9D69",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "a1b9bf0e675e90fa82bc340213731eb9ca67e7130f0f5fff729a21b66c9fbc8d"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b744d0e19032dfcd5a818e1cb7d1f26b95bb9d69"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/__init__.py",
+      "SPDXID": "SPDXRef-File--cam-tool-test---init--.py-99CC0AD65EE34E2C19C7BBE1B2E98783F60C5F26",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "bfc59a3a4292a522d8e62190baf1507868cde61c9b68bcb6543ede78f8bdfa15"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "99cc0ad65ee34e2c19c7bbe1b2e98783f60c5f26"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/valid.csc.yml",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-valid.csc.yml-2713BBCB038082FB82094E01433F40DABC70BD39",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "27224a24a8a909cf5aa560dc48c26ce68df252d9a704283b246b79c7aa072f37"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "2713bbcb038082fb82094e01433f40dabc70bd39"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/no_padding_bytes.csd",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-no-padding-bytes.csd-5737DEED8785E47DDAB3BA109B36A3C7B0637700",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "b67d4e82ebd05f157e5e8a6f0d398e009a8014745b70a63545d873a272f0b52c"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "5737deed8785e47ddab3ba109b36a3c7b0637700"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/no_meta_uuid.csc.yml",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-no-meta-uuid.csc.yml-D094E5DF930C9EB40112BDA356567FE2C81F0CBF",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "44bbb9f73a8f292e0e0a29fa9ae6e5ae89ebfd433fa378d3cf994e820e9fbff8"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "d094e5df930c9eb40112bda356567fe2c81f0cbf"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/success_case.msg_rcv",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-success-case.msg-rcv-531873E1E318A30E191041E59F1E926DCB1F375C",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "2db34ecc317f2336216155705bd35c36f27290c4b347f36a31368994a9ef66aa"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "531873e1e318a30e191041e59f1e926dcb1f375c"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/expected_msg_output-0",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-expected-msg-output-0-42A4902AFCCC45A3244E7E48C58264B267D26275",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "fb36bb731a48ea8725e38e65888bc98a6598bec54b2b4f360020baccf4b597b7"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "42a4902afccc45a3244e7e48c58264b267d26275"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./libcam/test/src/test_libcam.c",
+      "SPDXID": "SPDXRef-File--libcam-test-src-test-libcam.c-FA08DEF8E763F31C6890796AE23AE9477940648D",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "1994ddf2434ef984adf82ff739ddecc5a8892516cb063aeeef08fea4fdd6828c"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "fa08def8e763f31c6890796ae23ae9477940648d"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-uuid/test/src/test_suite.h",
+      "SPDXID": "SPDXRef-File--cam-uuid-test-src-test-suite.h-30E60F13DCD57065C8F3206914794786E9AEBFFF",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "c5572b8e6f334f12975c382b084a76d5b9ec99248a60a8ba426dcf073a51007c"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "30e60f13dcd57065c8f3206914794786e9aebfff"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/description",
+      "SPDXID": "SPDXRef-File--.git-description-9635F1B7E12C045212819DD934D809EF07EFA2F4",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "85ab6c163d43a17ea9cf7788308bca1466f1b0a8d1cc92e26e9bf63da4062aee"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "9635f1b7e12c045212819dd934d809ef07efa2f4"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.clang-format",
+      "SPDXID": "SPDXRef-File--.clang-format-6B5CD29FB1194B199BF9F6C37BF9234CF43E63C6",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "fff221e718d21da42d5d716dd08b7ec37c7ddc167d3c8bae879f02f877c52efb"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6b5cd29fb1194b199bf9f6c37bf9234cf43e63c6"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.readthedocs.yaml",
+      "SPDXID": "SPDXRef-File--.readthedocs.yaml-71E0A36B7643334D48EAD0A3C865120841629A5C",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "2d6afb1ce91c5f9ec5cd2469290f4156716253c59c5fda582b0338194f196ce6"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "71e0a36b7643334d48ead0a3c865120841629a5c"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.codeclimate.yml",
+      "SPDXID": "SPDXRef-File--.codeclimate.yml-B2CEE30FD5E2C2BB525F0019546094B4F2C6921A",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "5eb0e16e0933f6d26da0074f6914699f284b4b1bc24dd2d7a7dfcdc877920ac3"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b2cee30fd5e2c2bb525f0019546094b4f2c6921a"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./documentation/license_link.rst",
+      "SPDXID": "SPDXRef-File--documentation-license-link.rst-6E2E46EF9CA8EF0F8BBC0A3011BF6DF1B6578277",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "b6baeaa8aad43591b8ff2804e6da9c79fd60db0a1129056d3a743612f42f71de"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6e2e46ef9ca8ef0f8bbc0a3011bf6df1b6578277"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./documentation/manual/file_csc.rst",
+      "SPDXID": "SPDXRef-File--documentation-manual-file-csc.rst-A2DD41175AABDAD3A7D86428A646B514ACF6A927",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "5dd78ab811d5caa7b1bcbaf9386c79f8c66bb48cf22f116b7d3cddd7c039d915"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "a2dd41175aabdad3a7d86428a646b514acf6a927"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./documentation/cmake/FindSPHINX.cmake",
+      "SPDXID": "SPDXRef-File--documentation-cmake-FindSPHINX.cmake-523D03A6BBE1572A7935FFBC0473978AD99CE48A",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "57f9aae4cc22eb6b93a3e10340e80d673694aece7c77d3ac2d72b91a9f06b0c7"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "523d03a6bbe1572a7935ffbc0473978ad99ce48a"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/demos/project-gearshift-demo-scenario-integrationtests.md",
+      "SPDXID": "SPDXRef-File--docs-demos-project-gearshift-demo-scenario-integrationtests.md-96ABDE387BBCF05CED314CA2BB066EADB5D2E275",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "5bddd4cfa77245312ef980364786a03ed9d9e95f4440468f5d5283d3a02c6bad"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "96abde387bbcf05ced314ca2bb066eadb5d2e275"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/strictdoc/02_fsc_lite.sdoc",
+      "SPDXID": "SPDXRef-File--docs-strictdoc-02-fsc-lite.sdoc-441C5B9C5D87EF26CED32BC31FFDC5EECB6D5015",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "35fb170fe9dcd3df936d4e22c2904bd279aae1a6e8d619f56ef36980e1beb227"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "441c5b9c5d87ef26ced32bc31ffdc5eecb6d5015"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/strictdoc/evidence/EVID-007-deploy-message-chunking.txt",
+      "SPDXID": "SPDXRef-File--docs-strictdoc-evidence-EVID-007-deploy-message-chunking.txt-7B87AFED92003513E09735899EBE88E7B795D704",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "57dadd1930cea2c4fb015575b7df8a2fd6090b4f08e04d1b45c8d78a9767ce9d"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "7b87afed92003513e09735899ebe88e7b795d704"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/strictdoc/evidence/EVID-010-libcam-protocol-sequence.txt",
+      "SPDXID": "SPDXRef-File--docs-strictdoc-evidence-EVID-010-libcam-protocol-sequence.txt-EA033D404B5307566EF0D8C3CC6609D742428803",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "fc96a46e1f5de2f2b9369a5b088b29c22fcec48f61dee6d5e56fc0053598a648"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "ea033d404b5307566ef0d8c3cc6609d742428803"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/screencast-recordings/ScreencastUpdated.mp4",
+      "SPDXID": "SPDXRef-File--docs-screencast-recordings-ScreencastUpdated.mp4-5A1C1A319126ED0718432FC79534069491EBBDA3",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "134c1085f9084040aa897c7561d1fadb7ab8dc31244f438fa0b0aeee36598cd8"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "5a1c1a319126ed0718432fc79534069491ebbda3"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.github/workflows/build-cam-app_exper.yml",
+      "SPDXID": "SPDXRef-File--.github-workflows-build-cam-app-exper.yml-92C4B65CEA547955179D00C1E31DC235ED7D971E",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "cc0908b53d2d5aa0c42b7cfc1bd17a3beb42b2be4e8d0386526a01caa256b3c1"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "92c4b65cea547955179d00c1e31dc235ed7d971e"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.github/workflows/build-cam-app.yaml",
+      "SPDXID": "SPDXRef-File--.github-workflows-build-cam-app.yaml-E5CE4255BDEF6D765156DEBF52271E284A8AD22A",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "15d20e8ebaff57d0bcf1c73a96ba7341f3a468288ea4ea4c7578a0b1bab00913"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "e5ce4255bdef6d765156debf52271e284a8ad22a"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./test/fixture/config_deploy_invalid.csd",
+      "SPDXID": "SPDXRef-File--test-fixture-config-deploy-invalid.csd-3329494445A06C421C84B682F60CF28FEF665F5A",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "47eca3b1c53732e03da56ead7880918a283b59ded6236e4a70224dfb42b2d2cd"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "3329494445a06c421c84b682f60cf28fef665f5a"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/pyproject.toml",
+      "SPDXID": "SPDXRef-File--cam-tool-pyproject.toml-69538DF8B7CA45392165C8DE6931B98B5451BEDB",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "9fcce9b33f719d5a9226717fc973250662fffbf9275b54c329d408da68134267"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "69538df8b7ca45392165c8de6931b98b5451bedb"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/cam_tool/cam_csc.py",
+      "SPDXID": "SPDXRef-File--cam-tool-cam-tool-cam-csc.py-BA3F1CA77C45DCCD8FCC35CD35C14324C74E4A5D",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "64aa02982186f4f66cc5bde5dd4c25ae56a5b0d41dd53be596e2c718b5dc6751"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "ba3f1ca77c45dccd8fcc35cd35c14324c74e4a5d"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/invalid_uuid.csc.yml",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-invalid-uuid.csc.yml-497E5EC9D9ABDC9F0B43CA943F8BD4208E5E8980",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "eb6f1bc010ef9693f21b42deaa9aa9896a5ba7305806b98fd832f984c9e5ec2f"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "497e5ec9d9abdc9f0b43ca943f8bd4208e5e8980"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/error_case.msg_rcv",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-error-case.msg-rcv-6BD54C8B87265DCC3D62590E8CFCC543F713343D",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "fc9057747fd73d840a52511d23a87038103cd750711e6b2dee974926dd3c3b7b"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6bd54c8b87265dcc3d62590e8cfcc543f713343d"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/invalid_entry_sequence.csel",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-invalid-entry-sequence.csel-F71D87F20E75D641F4302E4D6AC4056CEEDAD090",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ad654662e41168c38c71126dedee0356926a89ef79916c164f0510e7982bdb10"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "f71d87f20e75d641f4302e4d6ac4056ceedad090"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/invalid_protocol_version.msg_rcv",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-invalid-protocol-version.msg-rcv-3F7A1905CD1D0B9B8C774C8E03363A123849E198",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "bc2a0d642bb05e3eea490f325a959374f599cd8e6c9833c492a702bb29a894c2"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "3f7a1905cd1d0b9b8c774c8e03363a123849e198"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/invalid_sequence_id.csel",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-invalid-sequence-id.csel-7918B1E5EA8F47236E74EA21438F97F66012F51E",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "fbe7f8e9480432f9c2d85c0a50339d848b3edbcac9ebace4b69024425134ff6b"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "7918b1e5ea8f47236e74ea21438f97f66012f51e"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./libcam/test/CMakeLists.txt",
+      "SPDXID": "SPDXRef-File--libcam-test-CMakeLists.txt-6D2DD90E4E04C809BF7701766993E69468AB5D1D",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "acfaef0d7a7b08b1bdb72f58a4db983646f4ef1c5e9aa6d1f1c71b5c4e009498"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6d2dd90e4e04c809bf7701766993e69468ab5d1d"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-uuid/include/cam_uuid.h",
+      "SPDXID": "SPDXRef-File--cam-uuid-include-cam-uuid.h-FF38CAD2730F332982C8A7801C328D3D27AB18ED",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "964e8e9704e965a36a7bea51fb0828ac081c208a99625362332a566d4e763fe3"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "ff38cad2730f332982c8a7801c328d3d27ab18ed"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/config",
+      "SPDXID": "SPDXRef-File--.git-config-627B8DA189E9287636A48F52793E0B016B7296B8",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "8145db1eb145296c0abcc1b5cc26c1c4232a478b58c7b109ca82b60f5e54ea6b"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "627b8da189e9287636a48f52793e0b016b7296b8"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/info/exclude",
+      "SPDXID": "SPDXRef-File--.git-info-exclude-C879DF015D97615050AFA7B9641E3352A1E701AC",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "6671fe83b7a07c8932ee89164d1f2793b2318058eb8b98dc5c06ee0a5a3b0ec1"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c879df015d97615050afa7b9641e3352a1e701ac"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/hooks/pre-receive.sample",
+      "SPDXID": "SPDXRef-File--.git-hooks-pre-receive.sample-705A17D259E7896F0082FE2E9F2C0C3B127BE5AC",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "a4c3d2b9c7bb3fd8d1441c31bd4ee71a595d66b44fcf49ddb310252320169989"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "705a17d259e7896f0082fe2e9f2c0c3b127be5ac"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/hooks/applypatch-msg.sample",
+      "SPDXID": "SPDXRef-File--.git-hooks-applypatch-msg.sample-4DE88EB95A5E93FD27E78B5FB3B5231A8D8917DD",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "0223497a0b8b033aa58a3a521b8629869386cf7ab0e2f101963d328aa62193f7"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "4de88eb95a5e93fd27e78b5fb3b5231a8d8917dd"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/CMakeLists.txt",
+      "SPDXID": "SPDXRef-File--cam-service-CMakeLists.txt-A344D3B230198DDB4E746D5D6294A24E55E3F590",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "bad58e124e833cdb466e6b6a0c106a5a0444b600174318e6a32982dfb42a7a80"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "a344d3b230198ddb4e746d5d6294a24e55e3f590"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/test/src/test_cam_fault.c",
+      "SPDXID": "SPDXRef-File--cam-service-test-src-test-cam-fault.c-C794D099ACB222BD254970C4B46A1B18DBDC1BE5",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "2267d5e7fb4642e9c9476be682beaa4263ec08b341b507e8faabaae082aed467"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c794d099acb222bd254970c4b46a1b18dbdc1be5"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/test/fixture/84085ddc-bc10-11ed-9a44-7ef9696e9dd8.csd",
+      "SPDXID": "SPDXRef-File--cam-service-test-fixture-84085ddc-bc10-11ed-9a44-7ef9696e9dd8.csd-4653DBEDB4C09D685AC8662927D0CFB1A48A9BF1",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "739ec5eb5128b62cef332dea1f09cc6f7b68411506b475f42b7f2262192b726d"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "4653dbedb4c09d685ac8662927d0cfb1a48a9bf1"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/src/cam_cmdline.c",
+      "SPDXID": "SPDXRef-File--cam-service-src-cam-cmdline.c-8AAD45DCCC0F09F9D4653920E6E3BEC1B9B239EB",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "5051d591a3b5f460414abc5810c5a825c27a997e2f60674e729d1f496159ecf7"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "8aad45dccc0f09f9d4653920e6e3bec1b9b239eb"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/src/cam_fault.h",
+      "SPDXID": "SPDXRef-File--cam-service-src-cam-fault.h-8A8573270E076ECE7A088118CB9DF4FA18C1B0CB",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "38fb3b5d27e50aaee9be9810423a94a243bca57028da021481863089678f8c1b"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "8a8573270e076ece7a088118cb9df4fa18c1b0cb"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./Dockerfiles/cam-image-zephyr/Dockerfile",
+      "SPDXID": "SPDXRef-File--Dockerfiles-cam-image-zephyr-Dockerfile-A497A8BC79C5A8AF188A18C5C466C70583FE4EDD",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "539c7854aa004cb225ed8dc59ef4804bf8f22151b62e2aaa432be763a7aa711e"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "a497a8bc79c5a8af188a18c5c466c70583fe4edd"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-app-example/cam-data/stream0.csc.yml",
+      "SPDXID": "SPDXRef-File--cam-app-example-cam-data-stream0.csc.yml-05B5987F38DC99E6B363989912B8DB3E92227614",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "5709f272ebe7c15df9abbcfe18ec327991ae7d142d57af79d3bc22279a72b3c9"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "05b5987f38dc99e6b363989912b8db3e92227614"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./documentation/manual/file_csel.rst",
+      "SPDXID": "SPDXRef-File--documentation-manual-file-csel.rst-F549E6C548D67CC78320C480B3C2201233026374",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "d0236906561da749427dd19357280b872972ae0d7f053620d055014f4c53a9d5"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "f549e6c548d67cc78320c480b3c2201233026374"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./documentation/images/cam_overview.svg",
+      "SPDXID": "SPDXRef-File--documentation-images-cam-overview.svg-43A589CA729079E8A986BA477D6CA04B230B775C",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "5bc672e9cc557ba3d9baa8ec3b673fd3edc9e64d71347707a1f00dade5c7496a"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "43a589ca729079e8a986ba477d6ca04b230b775c"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/demos/project-gearshift-demo-scenario-appsecurity-ghas.md",
+      "SPDXID": "SPDXRef-File--docs-demos-project-gearshift-demo-scenario-appsecurity-ghas.md-627EFF5DA7CBFC54615C036115E32798FF5FFD26",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "654796074ce6b95190f91828df03f17e1558ad3959d5d07b93674dccec5601e1"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "627eff5da7cbfc54615c036115e32798ff5ffd26"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/strictdoc/01_hara_lite.sdoc",
+      "SPDXID": "SPDXRef-File--docs-strictdoc-01-hara-lite.sdoc-60AD39D89246C86E24477722959BBC06363F7E16",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "c81adbe95f6d20e129d4eb509010b9a6adf0085139ead7f79d59196017ad8bc8"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "60ad39d89246c86e24477722959bbc06363f7e16"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/strictdoc/06_verification_plan.sdoc",
+      "SPDXID": "SPDXRef-File--docs-strictdoc-06-verification-plan.sdoc-222C8219081AA7FABFCC5A004DB677153080A619",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "c0a50a81c5e93637c327b440079320d255b715fdadfffbf78d7f59031c2ea848"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "222c8219081aa7fabfcc5a004db677153080a619"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/strictdoc/evidence/EVID-008-future-timestamp-rejection.txt",
+      "SPDXID": "SPDXRef-File--docs-strictdoc-evidence-EVID-008-future-timestamp-rejection.txt-708DA0856E63041F222573088402A4DD2430FBF1",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "05ff5943d3f92b1552dc67f5610fc185c4176a6810e640eb1357642a79203a4a"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "708da0856e63041f222573088402a4dd2430fbf1"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/screencast-recordings/Introduction_Navigation_Recording.mp4",
+      "SPDXID": "SPDXRef-File--docs-screencast-recordings-Introduction-Navigation-Recording.mp4-31986C4CDE5C1618B869675195AD67EEB5B4D378",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "e3b03a288393e018366501d1b3047e0ebef87e3c2a46d33be36ee262b1b3d5ca"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "31986c4cde5c1618b869675195ad67eeb5b4d378"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.github/workflows/strictdoc-export.yml",
+      "SPDXID": "SPDXRef-File--.github-workflows-strictdoc-export.yml-28E30D129435BE2720AE8698E0AA1DE260374E8A",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "f1e6d7fad8d9eba1b7a1437d72874eec714b8e7cfc5c750f8e5bb436b15bb29a"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "28e30d129435be2720ae8698e0aa1de260374e8a"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.github/workflows/repo-sync.yml",
+      "SPDXID": "SPDXRef-File--.github-workflows-repo-sync.yml-997A90A371BB51F06A898A45B9DFD7243517875E",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "e73d941e74a2959d3848f8dde33b7d093136be9733a53a8d00536f2729138b1b"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "997a90a371bb51f06a898a45b9dfd7243517875e"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./test/test_config_deploy.py",
+      "SPDXID": "SPDXRef-File--test-test-config-deploy.py-E9D3FEF98F9501198DCB644A49E68B2323846E22",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "f78defc67fcf02596616cbd259c7bc0e134513b6d96d73d576c676cd7edcf6f5"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "e9d3fef98f9501198dcb644a49e68b2323846e22"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./test/fixture/99085ddc-bc10-11ed-9a44-7ef9696e0000.csc.yml",
+      "SPDXID": "SPDXRef-File--test-fixture-99085ddc-bc10-11ed-9a44-7ef9696e0000.csc.yml-AEC52C1F0C022CD28C89CE74CD2F58B123CDB5C6",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "422c056f889f12ff8b78db674bb6967bbea60ffb80aa32d18ccf401e17609f1d"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "aec52c1f0c022cd28c89ce74cd2f58b123cdb5c6"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/cam_tool/cam_message.py",
+      "SPDXID": "SPDXRef-File--cam-tool-cam-tool-cam-message.py-AF52202BD621892C4D0C374FCB87EB70F8E3324E",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "fae4b13d938ee9a76202cb6eec1d12e513388bcef0c3b0a8fc50c4aecb9943db"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "af52202bd621892c4d0c374fcb87eb70f8e3324e"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/test_cam_message.py",
+      "SPDXID": "SPDXRef-File--cam-tool-test-test-cam-message.py-B02C92C2EDE06EC43605A4D5F26EF8782C644671",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "f5639c24501c40aeaf12bb1452c9e9649d1b2ceb18e94ee2f3b010e16e5c90fd"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b02c92c2ede06ec43605a4d5f26ef8782c644671"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/expected_msg_output-3",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-expected-msg-output-3-CEC96F2A2E96DCFDD7FDEF02351F15327319943F",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "b745b1996170947f813a8423f2bdd9f532bcc9c2a08e27c8ad866525637cdc62"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "cec96f2a2e96dcfdd7fdef02351f15327319943f"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/empty_file.csc.yml",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-empty-file.csc.yml-DA39A3EE5E6B4B0D3255BFEF95601890AFD80709",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/expected_output.csc",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-expected-output.csc-9A700CBED8FE9BC368E0090B1526547434C41276",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "5648dea3222d2d100fb0ced792253e2b2ea6f8eebbc7ea9fa3a3b19d5a127dba"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "9a700cbed8fe9bc368e0090b1526547434c41276"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/expected_msg_output-2",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-expected-msg-output-2-43816739F32FD401450F1528759953457B1EFE67",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "bcc7efbe8a24351d93307f4b9b19fa570bd52063d23b673507f9e8af2ea853ef"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "43816739f32fd401450f1528759953457b1efe67"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./libcam/CMakeLists.txt",
+      "SPDXID": "SPDXRef-File--libcam-CMakeLists.txt-508BCE3E9654DD5D571CB8D90150585862FE2E15",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "4651133a20d189e873b9d5bc9528864bb75dbd37726b1bdae29648c18544d09e"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "508bce3e9654dd5d571cb8d90150585862fe2e15"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./libcam/src/cam.c",
+      "SPDXID": "SPDXRef-File--libcam-src-cam.c-59D6C20D06B5D434F1FAD43D5CED2A11A5B9695C",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "0d2041b3c5a8f38c9348169fa10c301e0fb7f163050640c187b6de0a149358ee"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "59d6c20d06b5d434f1fad43d5ced2a11a5b9695c"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-uuid/src/cam_uuid.c",
+      "SPDXID": "SPDXRef-File--cam-uuid-src-cam-uuid.c-5DEC9CB37B34642434C84774014D3C2DEF39F507",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "b40de4f5d38a3045932fd5cb901ca508067b162d7114505ad82d7c6af4ee5e9b"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "5dec9cb37b34642434c84774014d3c2def39f507"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/logs/HEAD",
+      "SPDXID": "SPDXRef-File--.git-logs-HEAD-A1463843B44FEA0BF52CD4297FC21E495862E40E",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "cf00b190b548482e57b4f2f1ed2e4c89c73eeda817061d4aea7b2bd0839a0ba2"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "a1463843b44fea0bf52cd4297fc21e495862e40e"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/hooks/push-to-checkout.sample",
+      "SPDXID": "SPDXRef-File--.git-hooks-push-to-checkout.sample-508240328C8B55F8157C93C43BF5E291E5D2FBCB",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "a53d0741798b287c6dd7afa64aee473f305e65d3f49463bb9d7408ec3b12bf5f"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "508240328c8b55f8157c93c43bf5e291e5d2fbcb"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/hooks/commit-msg.sample",
+      "SPDXID": "SPDXRef-File--.git-hooks-commit-msg.sample-EE1ED5AAD98A435F2020B6DE35C173B75D9AFFAC",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "1f74d5e9292979b573ebd59741d46cb93ff391acdd083d340b94370753d92437"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "ee1ed5aad98a435f2020b6de35c173b75d9affac"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/hooks/pre-push.sample",
+      "SPDXID": "SPDXRef-File--.git-hooks-pre-push.sample-A599B773B930CA83DBC3A5C7C13059AC4A6EAEDC",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ecce9c7e04d3f5dd9d8ada81753dd1d549a9634b26770042b58dda00217d086a"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "a599b773b930ca83dbc3a5c7c13059ac4a6eaedc"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/test/src/test_suite.h",
+      "SPDXID": "SPDXRef-File--cam-service-test-src-test-suite.h-CDF9CDBFD5BBE73D030A9DF8D9665C5C35405A62",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "d7bbbc5501ad593ae8107c1bdea522fb5a6050d4a76ec28f7cf562260b9c9a2e"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "cdf9cdbfd5bbe73d030a9df8d9665c5c35405a62"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/test/fixture/84085ddc-bc10-11ed-9a44-7ef9696e9dd0.csd",
+      "SPDXID": "SPDXRef-File--cam-service-test-fixture-84085ddc-bc10-11ed-9a44-7ef9696e9dd0.csd-89E9678D98B0FC0EE2F9E9F767B164D365C8397A",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "41a976a3cdfdfe6611d58af965165601328130383dbad11e08acc056d22eb0a7"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "89e9678d98b0fc0ee2f9e9f767b164d365c8397a"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/src/cam_service.c",
+      "SPDXID": "SPDXRef-File--cam-service-src-cam-service.c-123EC5C51BE94C6CA827224150CE9DFB50560D51",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "630776c091394827fe465aea9742014c48f96de30f94b61b9a24bab01a9c789f"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "123ec5c51be94c6ca827224150ce9dfb50560d51"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/src/cam_byte_order.h",
+      "SPDXID": "SPDXRef-File--cam-service-src-cam-byte-order.h-CFEE563CC5E62DC268996487B4C493D8BE77FF67",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "f15cc25b761837da89d183a963878fa130a1481dc42c21dd2e7a53055e3d0eac"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "cfee563cc5e62dc268996487b4c493d8be77ff67"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./scripts/generate_spdx_design_sbom.py",
+      "SPDXID": "SPDXRef-File--scripts-generate-spdx-design-sbom.py-F2A347983DC7A3FDFB9208BCD4766CADF7CCBD05",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "3e33cacbeee7480207f20f4ec4ed27ddd61d345d681459a6865b7f079c6b7d32"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "f2a347983dc7a3fdfb9208bcd4766cadf7ccbd05"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-app-example/cam-data/stream2.csc.yml",
+      "SPDXID": "SPDXRef-File--cam-app-example-cam-data-stream2.csc.yml-E9A09C044562B6FB6D37E7E5A5F39235517BEB1F",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "6226156c456ba94c5ba3673230b216c5773c44f748d9420009f12ade878abb16"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "e9a09c044562b6fb6d37e7e5a5f39235517beb1f"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-app-example/src/cmdline.c",
+      "SPDXID": "SPDXRef-File--cam-app-example-src-cmdline.c-DD946FF294E3285DB10F38DCAFF0C0DEF2D2C255",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "95d1bdc7eed0d86f99db2d5a4803797fe6916348ec6f99566a1d1146253b9c21"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "dd946ff294e3285db10f38dcaff0c0def2d2c255"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./documentation/manual/message_protocol.rst",
+      "SPDXID": "SPDXRef-File--documentation-manual-message-protocol.rst-81BF4DD1113F1BFA114B3C24F487C25EC1DE411A",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "5d63154462814142b7f0f292a5da559ebee4389ce73c82119b8d83fd87faba4c"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "81bf4dd1113f1bfa114b3c24f487c25ec1de411a"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./documentation/images/cam_timings.svg",
+      "SPDXID": "SPDXRef-File--documentation-images-cam-timings.svg-212AEA7CE6959DCD5A9AD861693FA86FDA5862B0",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "60c1251cb5daab63987a55f04c9dd35265b0284d597645438e2a4d39aeda5551"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "212aea7ce6959dcd5a9ad861693fa86fda5862b0"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/demos/IntegrationDoc.md",
+      "SPDXID": "SPDXRef-File--docs-demos-IntegrationDoc.md-9253A9105C5600331DA5F412467EBC68670DB799",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "9a6ac7b9700a6b47f44f6f8c2bd7ba8f5b6bade98dceddec9a2b5ba2e2e37524"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "9253a9105c5600331da5f412467ebc68670db799"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/strictdoc/03_tsc_lite.sdoc",
+      "SPDXID": "SPDXRef-File--docs-strictdoc-03-tsc-lite.sdoc-0A6007ADC4AD1CD912F4A51887D411536CA3AAE6",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "50eadff65ff82dd1a03d4eb4a87f9c7d68a19424a321ac1b3d94b08e77fe4c3f"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "0a6007adc4ad1cd912f4a51887d411536ca3aae6"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/strictdoc/07_test_specs.sdoc",
+      "SPDXID": "SPDXRef-File--docs-strictdoc-07-test-specs.sdoc-801B381EADC023B6227BFA3A4E0CCAD2C9C9DCC0",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "9414c5054cabe20e81255c154b08245753ce3b0f7799e5b8c0df810f88be6f7b"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "801b381eadc023b6227bfa3a4e0ccad2c9c9dcc0"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/strictdoc/evidence/EVID-002-out-of-order-event-detection.txt",
+      "SPDXID": "SPDXRef-File--docs-strictdoc-evidence-EVID-002-out-of-order-event-detection.txt-F6D6BB3A3BD6BC9CC5495DBB440866A482517F37",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "f2281f8508ef75393bb787ed86c6f9d06ba75bceae2fac20927283000b46588d"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "f6d6bb3a3bd6bc9cc5495dbb440866a482517f37"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./documentation/manual/file_csd.rst",
+      "SPDXID": "SPDXRef-File--documentation-manual-file-csd.rst-BEF0A366BD190B3C9987FE6596FCCFBB3879EB3B",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "a7cb63218cbf1b993631c8ae9695caeaafe36c9f0704249116c20b42cd45d85f"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "bef0a366bd190b3c9987fe6596fccfbb3879eb3b"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./documentation/images/event_interval.svg",
+      "SPDXID": "SPDXRef-File--documentation-images-event-interval.svg-121EC6E3C791FDF92DF651A84CAC062D0C328466",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "4ecce26880fbe70b0fed4f0ded997c30a1d7ff946c68687fc060bd087082e1d5"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "121ec6e3c791fdf92df651a84cac062d0c328466"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/demos/cicd.png",
+      "SPDXID": "SPDXRef-File--docs-demos-cicd.png-1CC22BC2C252E9668F878003ACD10A0204CCA471",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "745daad2318ca57eaedb26ae417f0704be3d93e826634638e2f8d00ef0adc435"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "1cc22bc2c252e9668f878003acd10a0204cca471"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/strictdoc/04_ssr_cam.sdoc",
+      "SPDXID": "SPDXRef-File--docs-strictdoc-04-ssr-cam.sdoc-EE9983D01C412C9F73925C799C391C2920003330",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "aaa1cd0c7a85b3faf4bbd2cf4d37476d29a0e3a04e4da3e4de38651991dd9d84"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "ee9983d01c412c9f73925c799c391c2920003330"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/strictdoc/05_swa_cam.sdoc",
+      "SPDXID": "SPDXRef-File--docs-strictdoc-05-swa-cam.sdoc-9F15A3AA7EEB2F99FD3A031DB26DA9C2D89E4870",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "41f52f4ce8e5d35a7014d7f1c27a32230ed92be70d61fb79c50b36671d7791f2"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "9f15a3aa7eeb2f99fd3a031db26da9c2d89e4870"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/strictdoc/evidence/EVID-006-csc-validation-and-conversion.txt",
+      "SPDXID": "SPDXRef-File--docs-strictdoc-evidence-EVID-006-csc-validation-and-conversion.txt-D554A42A6064AAEAEC0441B452440D93314A97CF",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "762ddb1f6cc1365b3b2a3f1b44cedda7cf8c145ca857de43c065b978ca06ebfd"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "d554a42a6064aaeaec0441b452440d93314a97cf"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/screencast-recordings/TMUX_and_Installation.mp4",
+      "SPDXID": "SPDXRef-File--docs-screencast-recordings-TMUX-and-Installation.mp4-94759FDB0D2B2BDC81A54177857B633B58ECF40A",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "4750f07d685f3f1654588a9a734143bfdf8a7d6ee6f4d40f51d81efe9b6a042f"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "94759fdb0d2b2bdc81a54177857b633b58ecf40a"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.github/workflows/Kronos.yaml",
+      "SPDXID": "SPDXRef-File--.github-workflows-Kronos.yaml-93C30B82E49670E235C9947A73DE21546C57C382",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ea79dd0de1c0ea4261317fc5cf2384259353957f35bef8bccd8bd0bfe5296696"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "93c30b82e49670e235c9947a73de21546c57c382"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.github/workflows/corellium-saas.yaml",
+      "SPDXID": "SPDXRef-File--.github-workflows-corellium-saas.yaml-2331229D101363C470F8F1EAE01639C27D709AC7",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "3fdb1f37065f4a84ba44f0fa9c140d567ca3df4833460eff83e15434241b10aa"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "2331229d101363c470f8f1eae01639c27d709ac7"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./test/fixture/calibration_invalid_analyze.csel",
+      "SPDXID": "SPDXRef-File--test-fixture-calibration-invalid-analyze.csel-678DCFAE77E7B59A602C5B755A6028A01BAF9627",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "68a46b41f5da9d4e3414bedc48ad7b2059d4221b04dc70023de9703952137457"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "678dcfae77e7b59a602c5b755a6028a01baf9627"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./test/fixture/99085ddc-bc10-11ed-9a44-7ef9696e0001.csc.yml",
+      "SPDXID": "SPDXRef-File--test-fixture-99085ddc-bc10-11ed-9a44-7ef9696e0001.csc.yml-66A179E3CC4CA4E7A972F77C65988C623B4FB208",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "5474b43a3445383156fb41d50129558048d1a40c0c9a4261521734223d46ede1"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "66a179e3cc4ca4e7a972f77c65988c623b4fb208"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/cam_tool/cam_tool_run.py",
+      "SPDXID": "SPDXRef-File--cam-tool-cam-tool-cam-tool-run.py-B10839D60E38CC0EC8953A8D10B1DC7824738A04",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "05251e90479c7509827c90302363792097ab84b1c284c0af8c146214f8f4a607"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b10839d60e38cc0ec8953a8d10b1dc7824738a04"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/valid.csel",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-valid.csel-3329494445A06C421C84B682F60CF28FEF665F5A",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "47eca3b1c53732e03da56ead7880918a283b59ded6236e4a70224dfb42b2d2cd"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "3329494445a06c421c84b682f60cf28fef665f5a"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/non_periodic_event_entry.csel",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-non-periodic-event-entry.csel-CE978035A715CF666F14200CDB14A0DFA3897A29",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "23dc5d05f2039dc43d844de00d265369c1289ba37e6906ac9fb0f7b62a963c53"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "ce978035a715cf666f14200cdb14a0dfa3897a29"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/out_of_period_event_id.csel",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-out-of-period-event-id.csel-B0C7D1F868D84A1BB4EAABD3486A15B1CBCC0C8A",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "4bbec750a7dcc9b4f24165bffcd7a51f5ee4429c74ee15413caaa0383bf11a31"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b0c7d1f868d84a1bb4eaabd3486a15b1cbcc0c8a"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/no_alarms.csc.yml",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-no-alarms.csc.yml-F6D3CA69987F234B05AEC738CC90E110688804CD",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "daae054011b0e5e76ebbbea3ff3c90e863e0e15a39de6fef946cf779f82b2e28"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "f6d3ca69987f234b05aec738cc90e110688804cd"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/invalid_entry_format.csel",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-invalid-entry-format.csel-093D75799B926A2DF78DD3A00A092EFCF9974EEE",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "92d1393e8924210583e7cffe27f457e8861b6743fd991b94e14b201dbac92332"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "093d75799b926a2df78dd3a00a092efcf9974eee"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./libcam/include/cam.h",
+      "SPDXID": "SPDXRef-File--libcam-include-cam.h-7553478E86CC65768C7F2062779288069F681AE7",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "4d6a07fd21cb41a26482786ab85fd346a8d912c2a45ff68f9301711f22757cf9"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "7553478e86cc65768c7f2062779288069f681ae7"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-uuid/CMakeLists.txt",
+      "SPDXID": "SPDXRef-File--cam-uuid-CMakeLists.txt-429DF1FA2038DECE612F82FBE72D8A1D0DD1DB7A",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "8e845d98fe6f5675f98cdef1a44bebc03edaad21016a27c470b139983bff9f4c"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "429df1fa2038dece612f82fbe72d8a1d0dd1db7a"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/index",
+      "SPDXID": "SPDXRef-File--.git-index-3C98A6454DB89BA34127FA139BA0E5DD4F3E1AEE",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "3ae35bfaf415829fc0da62daaee62458e604c9c4421bfe2f8cbae3326e349a1c"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "3c98a6454db89ba34127fa139ba0e5dd4f3e1aee"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/logs/refs/heads/US-WS2-06_02",
+      "SPDXID": "SPDXRef-File--.git-logs-refs-heads-US-WS2-06-02-90B2D3944039C28E9D0EA7BDD49860523DEC12A1",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "28454a63bedbaec3a9adcbafa6d0297cb038893444d4af4061195a2cfb2cbf63"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "90b2d3944039c28e9d0ea7bdd49860523dec12a1"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/hooks/fsmonitor-watchman.sample",
+      "SPDXID": "SPDXRef-File--.git-hooks-fsmonitor-watchman.sample-0EC0EC9AC11111433D17EA79E0AE8CEC650DCFA4",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "e0549964e93897b519bd8e333c037e51fff0f88ba13e086a331592bf801fa1d0"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "0ec0ec9ac11111433d17ea79e0ae8cec650dcfa4"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/hooks/post-checkout",
+      "SPDXID": "SPDXRef-File--.git-hooks-post-checkout-34CCA5E573F14E1C8F36C447FD5005D7D93EBEA7",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "8d606e58cce98604696a4abcf3ae1ebde6f9f31ac72bb0d44e2444cc39f26030"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "34cca5e573f14e1c8f36c447fd5005d7d93ebea7"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/refs/heads/US-WS2-06_02",
+      "SPDXID": "SPDXRef-File--.git-refs-heads-US-WS2-06-02-49CF2A5B3160DFC9B009A4A3C26D978D684FFD3F",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "48862da5a1d0c1f527d4c1f03e9e01553eb24d917a365b505cad24e7db983da5"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "49cf2a5b3160dfc9b009a4a3c26d978d684ffd3f"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/test/src/test_cam_stream.c",
+      "SPDXID": "SPDXRef-File--cam-service-test-src-test-cam-stream.c-B1E0B2B807A8E108C8DB45C86745A51AD9E84A97",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "fbb335fb990249a683182b47f433501c54c3ce521d404296df27ac0e63cb61a3"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b1e0b2b807a8e108c8db45c86745a51ad9e84a97"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/test/fixture/84085ddc-bc10-11ed-9a44-7ef9696e9dd3.csd",
+      "SPDXID": "SPDXRef-File--cam-service-test-fixture-84085ddc-bc10-11ed-9a44-7ef9696e9dd3.csd-AE0F24D8FAB62DD878E6409B64F97A026EC7126F",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "5f42560eaa5a41e5c27bb16f890bd472b6bfddad3590397fb2e3e340f92d3027"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "ae0f24d8fab62dd878e6409b64f97a026ec7126f"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/src/cam_log.h",
+      "SPDXID": "SPDXRef-File--cam-service-src-cam-log.h-AD17683053FB4982EDF858A8C96A0F7244B0D077",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "d2cd0f9141846f995863738d1a23c1709b7bb8f7af473db13ffc9add7ccd2365"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "ad17683053fb4982edf858a8c96a0f7244b0d077"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/src/cam_fault.c",
+      "SPDXID": "SPDXRef-File--cam-service-src-cam-fault.c-062A76F5FDECA2B53E0632CDF727B831F1DCA408",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ecf580061fc6e6f0517fad6eaaecd26b67fc42717dcde0d995352935651df796"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "062a76f5fdeca2b53e0632cdf727b831f1dca408"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./Dockerfiles/cam-image/Dockerfile",
+      "SPDXID": "SPDXRef-File--Dockerfiles-cam-image-Dockerfile-9B16B2BA2DD4FAEE61BF68D3991DB04B59FAF302",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ba9866a604f01c91df79aa7185a406b4336ff2f08194067692defd6715f8abd2"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "9b16b2ba2dd4faee61bf68d3991db04b59faf302"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-app-example/cam-data/84085ddc-bc10-11ed-9a44-7ef9696e0003.csd",
+      "SPDXID": "SPDXRef-File--cam-app-example-cam-data-84085ddc-bc10-11ed-9a44-7ef9696e0003.csd-6F6ACA5EE68C3C576D862B5C766060F53E2EA828",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "76f6f0494c1fdf9afae727f3a21fec911497957e4f4219db7653e098e5ed2ea1"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6f6aca5ee68c3c576d862b5c766060f53e2ea828"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./documentation/manual/libcam_api.rst",
+      "SPDXID": "SPDXRef-File--documentation-manual-libcam-api.rst-02E25925E274224DB87DBA00762F95D86D3F72F5",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "9b6e07167975f464b2c81fd452a5f53e0db78f1ffce654edbcf0dd061154560e"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "02e25925e274224db87dba00762f95d86d3f72f5"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/.DS_Store",
+      "SPDXID": "SPDXRef-File--docs-.DS-Store-3FDBB98C715247247D3549E4E622E97F29C6E369",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "7387851e32fe2162fb1e758351eebe2cd3b836087859300147f71ce46ce82617"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "3fdbb98c715247247d3549e4e622e97f29c6e369"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/strictdoc/00_item_definition.sdoc",
+      "SPDXID": "SPDXRef-File--docs-strictdoc-00-item-definition.sdoc-B33028A11A42301C6E384B008EA93DAE78DB29B9",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ce58c5593f3a589acbe7496d8293e152b17e67d5e20b9c78bfbf14eb660f84e3"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b33028a11a42301c6e384b008ea93dae78db29b9"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/strictdoc/strictdoc.toml",
+      "SPDXID": "SPDXRef-File--docs-strictdoc-strictdoc.toml-57DD715261F13F14197A237D5C44C21C35268147",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "49978701fa0eb1bf0a4ae59777ca97b8d3c90eeb4717276949e0ccb8470123eb"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "57dd715261f13f14197a237d5c44c21c35268147"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/strictdoc/evidence/EVID-003-sequence-mismatch-fault.txt",
+      "SPDXID": "SPDXRef-File--docs-strictdoc-evidence-EVID-003-sequence-mismatch-fault.txt-7ACA608B64600100B9F5F53AB750912C0D34CC58",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "faae9818313fe439f84e1d97d812ee16c11cada5ae82bc7c631affc4ebecca14"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "7aca608b64600100b9f5f53ab750912c0d34cc58"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/strictdoc/evidence/EVID-005-event-before-start-fault.txt",
+      "SPDXID": "SPDXRef-File--docs-strictdoc-evidence-EVID-005-event-before-start-fault.txt-F738A8DB8ECFF9C604D31E2A783B2DFC48494F54",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "e95af6f3418a57aef8fbddfaaa13463600c4a28b2f10be8efcea6a7231fefaed"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "f738a8db8ecff9c604d31e2a783b2dfc48494f54"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.github/dependabot.yml",
+      "SPDXID": "SPDXRef-File--.github-dependabot.yml-3D2B68A042CA883BE6F12D33A24FABD3931FBC73",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "aad36a8d821d1705019256652894553150bac03dbaa95a00f4459fbc2c1c13b2"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "3d2b68a042ca883be6f12d33a24fabd3931fbc73"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.github/workflows/code-coverage.yaml",
+      "SPDXID": "SPDXRef-File--.github-workflows-code-coverage.yaml-96397A8E74EE740B15453C4EDF094515B5BF8CBD",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "d085056c61d53760ab5fa23eecd411e77f2ddc0f86f7d208903a47f7b5c941f4"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "96397a8e74ee740b15453c4edf094515b5bf8cbd"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.github/workflows/correlium.yaml",
+      "SPDXID": "SPDXRef-File--.github-workflows-correlium.yaml-E233632E89F7F03755E9D2F8A4B16317E65B9AAE",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "7735c260ff3605fa929d0ac5e48ea06f19c31e8594b17c0b294a1decd2890899"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "e233632e89f7f03755e9d2f8a4b16317e65b9aae"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./test/fixture/99085ddc-bc10-11ed-9a44-7ef9696e0000.csd",
+      "SPDXID": "SPDXRef-File--test-fixture-99085ddc-bc10-11ed-9a44-7ef9696e0000.csd-8CAD6A0C5B6F171CF8F0AF0BE03FB2070C8CD7C0",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "d40ace2ec09d58fd5073be91fc74ec50a330a6d451110b606b87f2cf817c6970"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "8cad6a0c5b6f171cf8f0af0be03fb2070c8cd7c0"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/cam_tool/cam_csd.py",
+      "SPDXID": "SPDXRef-File--cam-tool-cam-tool-cam-csd.py-6227BB362E49D0D96E6610527B3A5299CE7F4766",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "24bdd1ea7596e6bd3abd9f5262aa103d4b6b4d03c357e118820d348a005fb6ff"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6227bb362e49d0d96e6610527b3a5299ce7f4766"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/cam_tool/cam_deploy.py",
+      "SPDXID": "SPDXRef-File--cam-tool-cam-tool-cam-deploy.py-5098F7AA4441CBEB1D52C9F017999C43C6D055A8",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "e702cc440e169b917aa04db00d890296ab3eb955c208a5c2b4ce71e8aedb1c5d"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "5098f7aa4441cbeb1d52c9f017999c43c6d055a8"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/invalid_timeout.csc.yml",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-invalid-timeout.csc.yml-F29793EED18438DC1BFD6B3D3356FAA3B951657B",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "c35c9a81139630b41b98850a83d42ba54b6bd3023b724d5b883d2cdec55747ff"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "f29793eed18438dc1bfd6b3d3356faa3b951657b"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/no_version.csc.yml",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-no-version.csc.yml-64AF7B974DCB6CD16359FD34F6DA3A7B598FA0D2",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "08abfe1b763b57ed7a2af893e5236c4ada96c84d12f7f3d91add7e32be291ab8"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "64af7b974dcb6cd16359fd34f6da3a7b598fa0d2"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/invalid_version.csc.yml",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-invalid-version.csc.yml-08BA3ADE3C14F15129F6165C47C429BE76674946",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "697a2a5b5e38f9fe9ce6368a46563bbb4d455c87f66ae6f98c0b63b4d98aea2b"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "08ba3ade3c14f15129f6165c47c429be76674946"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/file_size_overflow.csd",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-file-size-overflow.csd-70F9465FE4A5A7C41EACF00DAC3B9F61002C519C",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "e52073faf95c7e8ea2e92c544ac70ad87bae01ee22d28daacaa50e428af1caa5"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "70f9465fe4a5a7c41eacf00dac3b9f61002c519c"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/unexpected_status_type.msg_rcv",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-unexpected-status-type.msg-rcv-C4E1A68A47741430037C51F1CADD5E2F80DEBBE3",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "bd1ef47cd7456c52c43c92ee70f385e5c286c10922aa47be39af3f30c6bd1b04"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c4e1a68a47741430037c51f1cadd5e2f80debbe3"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./libcam/test/src/test_suite.c",
+      "SPDXID": "SPDXRef-File--libcam-test-src-test-suite.c-A1AF64B2AAEF31D7E5E03BC1A17A7EF16465A838",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "df10e3e23f7a8cedbd10e54a36f3e6eda3986e8bc816810456a20624b66d274b"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "a1af64b2aaef31d7e5e03bc1a17a7ef16465a838"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-uuid/test/CMakeLists.txt",
+      "SPDXID": "SPDXRef-File--cam-uuid-test-CMakeLists.txt-73529D565EAB077BE2941022E5A881541529D7F0",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "801497af106e5afff6a52a603458567c686dab19abad47bd631f678887b14d5f"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "73529d565eab077be2941022e5a881541529d7f0"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/config.worktree",
+      "SPDXID": "SPDXRef-File--.git-config.worktree-CA859A5B32728E6B456D4E5011D9011BB638AC1C",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "443a5f645c23c3d0c0aa09f634b2ad111d46ef61946b598a2fb311678ab47454"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "ca859a5b32728e6b456d4e5011d9011bb638ac1c"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/objects/pack/pack-efbf6ffb6330dcbce25c762a37aac52ce143111e.idx",
+      "SPDXID": "SPDXRef-File--.git-objects-pack-pack-efbf6ffb6330dcbce25c762a37aac52ce143111e.idx-51672A6BBA16CCE665A16362BDE68392DB84FDCF",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ff6e9612765c53b15e700f7861ba451582059348dd5a9781449e33225b2627e3"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "51672a6bba16cce665a16362bde68392db84fdcf"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/hooks/pre-applypatch.sample",
+      "SPDXID": "SPDXRef-File--.git-hooks-pre-applypatch.sample-F208287C1A92525DE9F5462E905A9D31DE1E2D75",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "e15c5b469ea3e0a695bea6f2c82bcf8e62821074939ddd85b77e0007ff165475"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "f208287c1a92525de9f5462e905a9d31de1e2d75"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/hooks/pre-rebase.sample",
+      "SPDXID": "SPDXRef-File--.git-hooks-pre-rebase.sample-288EFDC0027DB4CFD8B7C47C4AEDDBA09B6DED12",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "4febce867790052338076f4e66cc47efb14879d18097d1d61c8261859eaaa7b3"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "288efdc0027db4cfd8b7c47c4aeddba09b6ded12"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/common/cam_message.h",
+      "SPDXID": "SPDXRef-File--cam-service-common-cam-message.h-5A3730C811AD621A212740FD29F45B63EA8C64AD",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "27570bdd8c3c9035d2f33cae0eb29429b84be93f5c623e05f69455afe68ec94d"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "5a3730c811ad621a212740fd29f45b63ea8c64ad"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/test/src/posix_call_utils.h",
+      "SPDXID": "SPDXRef-File--cam-service-test-src-posix-call-utils.h-5A708BD5310DBEECE6A6080441282457718E7B05",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "8c831cac017b2e08393e4012ca77bee67d2f04c45da5f94af08104a2083c631f"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "5a708bd5310dbeece6a6080441282457718e7b05"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/test/fixture/84085ddc-bc10-11ed-9a44-7ef9696e9dd4.csd",
+      "SPDXID": "SPDXRef-File--cam-service-test-fixture-84085ddc-bc10-11ed-9a44-7ef9696e9dd4.csd-93CEBCFF20A0D6BD76387C9B31399335CA1753CF",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "95b67b06290ed72b4d8990e6b4b5bd4ae2a34da0f60ac26db0a697c009906264"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "93cebcff20a0d6bd76387c9b31399335ca1753cf"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/src/cam_config.c",
+      "SPDXID": "SPDXRef-File--cam-service-src-cam-config.c-A33EF64845B1C4765FAF99DB96CB96A4CCA9DD2E",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ae12d337104cd30e7a85a566a49b844dcef44118b83ccd59e64cba574a5da36c"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "a33ef64845b1c4765faf99db96cb96a4cca9dd2e"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/src/cam_socket.h",
+      "SPDXID": "SPDXRef-File--cam-service-src-cam-socket.h-DB7379FF8E36074013239786061C8128A9F12175",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "bffb37511d7b3e814fabaa1e58a9e561fd28b5220e1f5dfee38c34594f072c37"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "db7379ff8e36074013239786061c8128a9f12175"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-app-example/cam-data/stream3.csc.yml",
+      "SPDXID": "SPDXRef-File--cam-app-example-cam-data-stream3.csc.yml-CAF7B6B3E42354802A33581855DD5EBE8B0FF855",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "d69617a72edd0050b0288b4b8a6004bab44f9ec271d298e9265318f5b641150c"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "caf7b6b3e42354802a33581855dd5ebe8b0ff855"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./documentation/manual/index.rst",
+      "SPDXID": "SPDXRef-File--documentation-manual-index.rst-6000F7F3027086ED04B6D2CE5B649AE2A0CE8DDE",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "fe64b83ed1ab948f45fe8a939329f73499de37c89b8be5abc443f87429f289fb"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6000f7f3027086ed04b6d2ce5b649ae2a0ce8dde"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/demos/project-gearshift-demo-scenario-copilot.md",
+      "SPDXID": "SPDXRef-File--docs-demos-project-gearshift-demo-scenario-copilot.md-DADE9124CCA3B182500FEDF4E21045D3F2D37092",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "71b3b21c6c249af14fee869e7813f05783164976e3637aca8c395fcd1d6d1e98"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "dade9124cca3b182500fedf4e21045d3f2d37092"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/strictdoc/08_evidence_log.sdoc",
+      "SPDXID": "SPDXRef-File--docs-strictdoc-08-evidence-log.sdoc-C7EAE589EDA66EF750173C9EE3219B1351A89694",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "5f8bdf7fa0bb65dd97095c2e78534cf099580d89f0a53bd6a7c615cad1fe6e62"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c7eae589eda66ef750173c9ee3219b1351a89694"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/strictdoc/EXPORT_INSTRUCTIONS.md",
+      "SPDXID": "SPDXRef-File--docs-strictdoc-EXPORT-INSTRUCTIONS.md-2501658D15C120630C7832F07E05942BD02F9A92",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "b044f6e7f2e8d80c24803ce33b3d00e0adff4313239b95d203c1008da9703f72"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "2501658d15c120630c7832f07e05942bd02f9a92"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/strictdoc/evidence/EVID-004-start-to-first-event-timeout.txt",
+      "SPDXID": "SPDXRef-File--docs-strictdoc-evidence-EVID-004-start-to-first-event-timeout.txt-50BDFB19E32CA59800505F1C60530B506A4F5264",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ec2f511f8582ad42adf17c9633f8d676a75a5feea54b0f6d464ff483f4d4ae82"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "50bdfb19e32ca59800505f1c60530b506a4f5264"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/strictdoc/evidence/EVID-012-ci-sbom-artifact.txt",
+      "SPDXID": "SPDXRef-File--docs-strictdoc-evidence-EVID-012-ci-sbom-artifact.txt-BE4E7E0B040AE85FA02914991445D29B27537383",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "47161062db164faa81df533b7820580877b313e0820ca131a44a9b0120d72096"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "be4e7e0b040ae85fa02914991445d29b27537383"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.github/workflows/super-linter.yaml",
+      "SPDXID": "SPDXRef-File--.github-workflows-super-linter.yaml-A4D9459C3877B00E6FA98054D10250ADA592E960",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "384d18b7254045c7b94e48873151c9b205e231245bb8c6c2a7e6200da443ea68"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "a4d9459c3877b00e6fa98054d10250ada592e960"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.github/workflows/sbom_exper2.yml",
+      "SPDXID": "SPDXRef-File--.github-workflows-sbom-exper2.yml-E3562936495B7045E97B5BE23FFCC104EB1C9484",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "32fb627160ef55960fcbd808596587a53ecc3a4af2fd7eee4a33b3820cc1c398"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "e3562936495b7045e97b5be23ffcc104eb1c9484"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./test/test_calibration.py",
+      "SPDXID": "SPDXRef-File--test-test-calibration.py-C89FCFA1CE881D2D7D1263C88C3A962D2DAF91D1",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "8f1a2edb3e95ddcbfef1c118696e363c0a469c207d3676de79b0296fb6141fd2"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c89fcfa1ce881d2d7d1263c88c3a962d2daf91d1"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./test/fixture/config_deploy_valid.csd",
+      "SPDXID": "SPDXRef-File--test-fixture-config-deploy-valid.csd-83CC858D76EC1456512DFFA407E8893E3B3997FF",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "da6c171e6eb22e031686bc5b0c6a4335e50103e84c9e52d38349e1ed316df39c"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "83cc858d76ec1456512dffa407e8893e3b3997ff"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/cam_tool/cam_analyze.py",
+      "SPDXID": "SPDXRef-File--cam-tool-cam-tool-cam-analyze.py-B7F2804A15B69FE382C7D56ED940C4691B7846BB",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "be02db66388fdfbd7dea6cc9936ffa190efa0bc6f668ec3e9aaceebe99b099a0"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b7f2804a15b69fe382c7d56ed940c4691b7846bb"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/test_cam_csd.py",
+      "SPDXID": "SPDXRef-File--cam-tool-test-test-cam-csd.py-A8EF645A845E0671A682E6EAA816F20728914CC4",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "a703284cfbd7cec6fb5c3183b998320b592121add204774050710dd65b485784"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "a8ef645a845e0671a682e6eaa816f20728914cc4"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/inconsistent_uuid.msg_rcv",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-inconsistent-uuid.msg-rcv-F51A3E3AA4A405B281EE23C4A5DA4BACBE64C8D5",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ef0b5a8a0733361bb5909947ce4eea9df6a8b90c1d57385d3728e674be1c04c0"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "f51a3e3aa4a405b281ee23c4a5da4bacbe64c8d5"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/invalid_entry_type.csel",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-invalid-entry-type.csel-47CEA57F0303B2C20AC64884262A907A1B832263",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "7b9094fcf38d313a36c1e63224da752029ece50bd14031067f676468747553af"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "47cea57f0303b2c20ac64884262a907a1b832263"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/invalid_command_id.msg_rcv",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-invalid-command-id.msg-rcv-6892044A8100A5425A569EB2127A53914DBED544",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ca91fbc8efae53bb1f88a3d0d8ed983f35dfc65f6f4210374491049c7c6814f6"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6892044a8100a5425a569eb2127a53914dbed544"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/no_padding_bytes.csel",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-no-padding-bytes.csel-6022672C7971BE526F9CBB4B7FD4E6F3467DCF04",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "caab470eb1d01a2df8d1dc0fc4e4ead9b4a93c13c79ba408464970d5c20bb2e2"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6022672c7971be526f9cbb4b7fd4e6f3467dcf04"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/no_meta.csc.yml",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-no-meta.csc.yml-51A03E2DD226DE200EAB9B90FD5D85A9CB0BC05A",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ce3fdb1245f71985aa05d5507f28ce74e2e2b5a5d006a28791074268fd5c0478"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "51a03e2dd226de200eab9b90fd5d85a9cb0bc05a"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./libcam/test/src/test_suite.h",
+      "SPDXID": "SPDXRef-File--libcam-test-src-test-suite.h-30E60F13DCD57065C8F3206914794786E9AEBFFF",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "c5572b8e6f334f12975c382b084a76d5b9ec99248a60a8ba426dcf073a51007c"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "30e60f13dcd57065c8f3206914794786e9aebfff"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-uuid/test/src/test_suite.c",
+      "SPDXID": "SPDXRef-File--cam-uuid-test-src-test-suite.c-A29C11054F5F209D10963CEDB0018D9D561AE899",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "005fb283d680fa68aebfba395d97ac6d4b00d2e3cafb02586da177d3a765dfa4"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "a29c11054f5f209d10963cedb0018d9d561ae899"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/shallow",
+      "SPDXID": "SPDXRef-File--.git-shallow-49CF2A5B3160DFC9B009A4A3C26D978D684FFD3F",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "48862da5a1d0c1f527d4c1f03e9e01553eb24d917a365b505cad24e7db983da5"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "49cf2a5b3160dfc9b009a4a3c26d978d684ffd3f"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/objects/pack/pack-efbf6ffb6330dcbce25c762a37aac52ce143111e.rev",
+      "SPDXID": "SPDXRef-File--.git-objects-pack-pack-efbf6ffb6330dcbce25c762a37aac52ce143111e.rev-DCE4E2D730A59CE9DB954159E090AE4178CF6CC9",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "2d6bc16b8f310472b9cb594abfeef14e7c8b0f06e2556b67832e7b65432d3d7e"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "dce4e2d730a59ce9db954159e090ae4178cf6cc9"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/hooks/post-update.sample",
+      "SPDXID": "SPDXRef-File--.git-hooks-post-update.sample-B614C2F63DA7DCA9F1DB2E7ADE61EF30448FC96C",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "81765af2daef323061dcbc5e61fc16481cb74b3bac9ad8a174b186523586f6c5"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b614c2f63da7dca9f1db2e7ade61ef30448fc96c"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/hooks/pre-merge-commit.sample",
+      "SPDXID": "SPDXRef-File--.git-hooks-pre-merge-commit.sample-04C64E58BC25C149482ED45DBD79E40EFFB89EB7",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "d3825a70337940ebbd0a5c072984e13245920cdf8898bd225c8d27a6dfc9cb53"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "04c64e58bc25c149482ed45dbd79e40effb89eb7"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/test/CMakeLists.txt",
+      "SPDXID": "SPDXRef-File--cam-service-test-CMakeLists.txt-6EF2225B24DA4CCBA84F68EA89D96503E208C29D",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "1a8f789449307ed9da4f75400e7e8641323efc17fd1ce4937588cf26f978d582"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6ef2225b24da4ccba84f68ea89d96503e208c29d"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/test/src/test_cam_socket.c",
+      "SPDXID": "SPDXRef-File--cam-service-test-src-test-cam-socket.c-DC3E53359233F8D64E9717A909A03EFC9307CC92",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "7f3377627faca839db347fb40735c0a05a5f0a6bc811fc9fef8cdd5a474a6e32"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "dc3e53359233f8d64e9717a909a03efc9307cc92"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/test/fixture/84085ddc-bc10-11ed-9a44-7ef9696e9dd7.csd",
+      "SPDXID": "SPDXRef-File--cam-service-test-fixture-84085ddc-bc10-11ed-9a44-7ef9696e9dd7.csd-CBE5C5E17960713783A419D122433B548A78E933",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "dd06ff27133cbacc67498534ced0b5f1155d16c7d2cfd7c390d0c3b3e0f103f1"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "cbe5c5e17960713783a419d122433b548a78e933"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/src/cam_stream.h",
+      "SPDXID": "SPDXRef-File--cam-service-src-cam-stream.h-07CC268E59C3E5286D0EEF70E55D50D18B40B82E",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "5df2a2104db4ab5a5cafca3397c0e2eaf5f5750db295707938b8f19066d87755"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "07cc268e59c3e5286d0eef70e55d50d18b40b82e"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/src/cam_config.h",
+      "SPDXID": "SPDXRef-File--cam-service-src-cam-config.h-983C9B066BDEDEF0B10DF31CCB8B390CC0D5B0A5",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "3fcfeeef52d8b6d726169dcf3e184c8f04a5112ebcd01c7d053ecde2c06d2025"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "983c9b066bdedef0b10df31ccb8b390cc0d5b0a5"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-app-example/CMakeLists.txt",
+      "SPDXID": "SPDXRef-File--cam-app-example-CMakeLists.txt-7CE727E657055E814EA31C91E9C3C4D8525129EB",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "128013dbc43ed52c538fa7f167f059780299bf9eaa275c8f9092c19698777cfc"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "7ce727e657055e814ea31c91e9c3c4d8525129eb"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-app-example/cam-data/84085ddc-bc10-11ed-9a44-7ef9696e0001.csd",
+      "SPDXID": "SPDXRef-File--cam-app-example-cam-data-84085ddc-bc10-11ed-9a44-7ef9696e0001.csd-CA32F5D6E9EE31C51FD93739834F7FF67E0AAA93",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ac74c5ab104d3cc732e1bad44bd008fbdb86fe85bd6bea20d7cf6d1ca97edd07"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "ca32f5d6e9ee31c51fd93739834f7ff67e0aaa93"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./documentation/images/fault_injection.svg",
+      "SPDXID": "SPDXRef-File--documentation-images-fault-injection.svg-85911D560DBF135B6635C5E669BB6A0571E69398",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "71dbb0739fca3076b51bae79e730a1b1a06c58b9bc75bc93f765f4155700c514"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "85911d560dbf135b6635c5e669bb6a0571e69398"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/demos/project-gearshift-demo-scenario-unittests.md",
+      "SPDXID": "SPDXRef-File--docs-demos-project-gearshift-demo-scenario-unittests.md-2048CB17747D80661512FEF0560836E15259387E",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "3fbbc89cb13ce0650db6c3da97205cc439f6909394850c7dfaaa07e794d94790"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "2048cb17747d80661512fef0560836e15259387e"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/strictdoc/cam_fusa.sgra",
+      "SPDXID": "SPDXRef-File--docs-strictdoc-cam-fusa.sgra-F51F528801ACABD35CD92B4B2824F6419FCF78B6",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "46b47a99318a778e801547932f0d52f101f68e40f845be13b5a898735905c0f1"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "f51f528801acabd35cd92b4b2824f6419fcf78b6"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/strictdoc/demo-script.md",
+      "SPDXID": "SPDXRef-File--docs-strictdoc-demo-script.md-A409B1CA88D6E07E575411B260D4BE6BBAD680A8",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "d2ae8d476e4df6b2c74526fc4eb8c767e144bd57194ca097b796f0aac6ab4cb0"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "a409b1ca88d6e07e575411b260d4be6bbad680a8"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/strictdoc/evidence/EVID-001-temporal-fault-detection.txt",
+      "SPDXID": "SPDXRef-File--docs-strictdoc-evidence-EVID-001-temporal-fault-detection.txt-1375D89BF1BF435171B2EAE4334E24781601E5BB",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "e85c685e0ce93bd6956bcb3c9a0d5560763dccb2dc3a6ce94fda34bbc032d48d"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "1375d89bf1bf435171b2eae4334e24781601e5bb"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/screencast-recordings/CAMDemo_Automation_results.mp4",
+      "SPDXID": "SPDXRef-File--docs-screencast-recordings-CAMDemo-Automation-results.mp4-03D57D5CE2FC70D330C1757A0CEFFB1C9924E3FB",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "360705509fb2bdcb23e30c3fbd4c8fd1d0f72d45fd403f163ec78e58eb470343"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "03d57d5ce2fc70d330c1757a0ceffb1c9924e3fb"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.github/workflows/automated-kas-setup.yml",
+      "SPDXID": "SPDXRef-File--.github-workflows-automated-kas-setup.yml-13233442371BD36EEFAB2CFC0DD53DEE3591EA34",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "faa0b0a370ae8361768f413dc926d651d0a0e6054a41d69c83e9824ec6c1a068"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "13233442371bd36eefab2cfc0dd53dee3591ea34"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.github/workflows/kas-auto-build.yml",
+      "SPDXID": "SPDXRef-File--.github-workflows-kas-auto-build.yml-BCA65F4579DB4B6424E88E7184147451015AC94C",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "fe842d4d647e3b6b813f8bbc1d8bdcaf80d9363fe185b4da3ba8cd4da7115383"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "bca65f4579db4b6424e88e7184147451015ac94c"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./test/test_static_config.py",
+      "SPDXID": "SPDXRef-File--test-test-static-config.py-47FF9981FC9B1718C94E13C3E0E5C15DAA0F6549",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "2944ef3be144e8fed7b512fb6c16f03276654df10946f1b294638ac1152f015c"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "47ff9981fc9b1718c94e13c3e0e5c15daa0f6549"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./test/fixture/calibration_analyze.csel",
+      "SPDXID": "SPDXRef-File--test-fixture-calibration-analyze.csel-3329494445A06C421C84B682F60CF28FEF665F5A",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "47eca3b1c53732e03da56ead7880918a283b59ded6236e4a70224dfb42b2d2cd"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "3329494445a06c421c84b682f60cf28fef665f5a"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/cam_tool/__init__.py",
+      "SPDXID": "SPDXRef-File--cam-tool-cam-tool---init--.py-99CC0AD65EE34E2C19C7BBE1B2E98783F60C5F26",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "bfc59a3a4292a522d8e62190baf1507868cde61c9b68bcb6543ede78f8bdfa15"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "99cc0ad65ee34e2c19c7bbe1b2e98783f60c5f26"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/test_cam_csc.py",
+      "SPDXID": "SPDXRef-File--cam-tool-test-test-cam-csc.py-63FD5D70BB8D5AE1B0AC26D8937F9EC6249D2967",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "56fa8322302ef97feaa5ab68ca0827c3965a20b87b03a6559a61426854a0e45f"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "63fd5d70bb8d5ae1b0ac26d8937f9ec6249d2967"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/invalid_mode_id.csc.yml",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-invalid-mode-id.csc.yml-E5B5755AB1159298FC475E58579FB0F69622CB49",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "f5ee89929b1b6a54caf0220df3532b5ab14e4e66ed3a8fcbf4d6f3aedb1ab384"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "e5b5755ab1159298fc475e58579fb0f69622cb49"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/invalid_name.csc.yml",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-invalid-name.csc.yml-97DD33F4CC67022B25DB195EA76742D1D69AB4CE",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "1ae166bade2b42fc90fb599a17e440848e0861e6039ce22e849f483633204bc6"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "97dd33f4cc67022b25db195ea76742d1d69ab4ce"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/invalid_message_size.msg_rcv",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-invalid-message-size.msg-rcv-3339B43BB254748746D13FB535E8FED71A0CF965",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "90aedfcdd9edaadfdb5bca6694add275e13975dbaabfc90700625e1efedc399b"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "3339b43bb254748746d13fb535e8fed71a0cf965"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/expected_msg_output-1",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-expected-msg-output-1-708DB2D675705C43916EA51990AA853EBB69937D",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "91f0038710a910bf0f8a60d3ea50b2cf13d702fd9a4a0cb03673624db75084e3"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "708db2d675705c43916ea51990aa853ebb69937d"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/no_meta_name.csc.yml",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-no-meta-name.csc.yml-A8E9876D88DE9C60EB7618F1B2C5D170FA16EAB2",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "8e4073b0c8cc64453400f57dc4be2be3b547864dc2cd5a2d5d206c96e6877a37"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "a8e9876d88de9c60eb7618f1b2c5d170fa16eab2"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./libcam/test/fixture/expected_output.csel",
+      "SPDXID": "SPDXRef-File--libcam-test-fixture-expected-output.csel-EF6628FAB17D7E0F5F566DBE434362BDB3F228DF",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "55a05e498d7eef4a634d323867880f9c0113fe9ef243c4b356ec650e4869977c"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "ef6628fab17d7e0f5f566dbe434362bdb3f228df"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-uuid/test/src/test_cam_uuid.c",
+      "SPDXID": "SPDXRef-File--cam-uuid-test-src-test-cam-uuid.c-068016D85D9E746E6CDA81B42A760798CE03BEE1",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ca543f4cb66984a335862ca754dfa84f13a96c9c234145334d50a5d305e9db8e"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "068016d85d9e746e6cda81b42a760798ce03bee1"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/FETCH_HEAD",
+      "SPDXID": "SPDXRef-File--.git-FETCH-HEAD-3C962B3AE8B546A1EF13FF494C5A9AFF88EB870B",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "2f2209fa1f33fd55868d2ca6afcafc3139bd5b1c327701ceaaf8454e780e0136"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "3c962b3ae8b546a1ef13ff494c5a9aff88eb870b"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/hooks/pre-push",
+      "SPDXID": "SPDXRef-File--.git-hooks-pre-push-6145042684084DFE68CED3427E8F0A7671276831",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "a52d0510d0f8c75e27852156ec6f7791f0d8ed65fc58fcc368dd1de0a60a1d74"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6145042684084dfe68ced3427e8f0a7671276831"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/hooks/pre-commit.sample",
+      "SPDXID": "SPDXRef-File--.git-hooks-pre-commit.sample-8093D68E142DB52DCAB2215E770BA0BBE4CFBF24",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "57185b7b9f05239d7ab52db045f5b89eb31348d7b2177eab214f5eb872e1971b"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "8093d68e142db52dcab2215e770ba0bbe4cfbf24"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/hooks/post-merge",
+      "SPDXID": "SPDXRef-File--.git-hooks-post-merge-02D6A0E420A63C99AA9ACD43445F0D8DC99E35E3",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "cecb594e8fa65831654fc95e96db9f1249e09c52810c6fbb2b428280aac22158"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "02d6a0e420a63c99aa9acd43445f0d8dc99e35e3"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/test/src/test_cam_config.c",
+      "SPDXID": "SPDXRef-File--cam-service-test-src-test-cam-config.c-3A4770126BF91DD692B1134A7B9C7EB2BFD15DDA",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "81898e1bf48d5730cf1768d139bae4805f6291d26c6ebf8dbc300de8d40664dd"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "3a4770126bf91dd692b1134a7b9c7eb2bfd15dda"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/test/fixture/84085ddc-bc10-11ed-9a44-7ef9696e9dd9.csd",
+      "SPDXID": "SPDXRef-File--cam-service-test-fixture-84085ddc-bc10-11ed-9a44-7ef9696e9dd9.csd-73C7E4D2BF01A74515C7AD0D73A7A4CCAC333D0D",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "7fe5b50bed5d0c9aea39e59f1302efdccdf9c67f771d010a871bac072ce7ac9d"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "73c7e4d2bf01a74515c7ad0d73a7a4ccac333d0d"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/src/cam_cmdline.h",
+      "SPDXID": "SPDXRef-File--cam-service-src-cam-cmdline.h-435C56EE8A65A388D42B1FBF03CC824AE3CE3DB2",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "8babb099f512d5625bd312f29c46ed02541f2c32ce8446ced482b0043bf9e44f"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "435c56ee8a65a388d42b1fbf03cc824ae3ce3db2"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/src/cam_fault_driver_itf.h",
+      "SPDXID": "SPDXRef-File--cam-service-src-cam-fault-driver-itf.h-B1BFF13B18EA906B194D5601C2F2C621BACFF032",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "bfeb2ecc264a45f14805208ab532bfaa8a045674e48f771bfac7498760309af6"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b1bff13b18ea906b194d5601c2f2c621bacff032"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./scripts/lint_strictdoc_traceability.py",
+      "SPDXID": "SPDXRef-File--scripts-lint-strictdoc-traceability.py-DDD7CB87C23A9016FF55BA965C2C66EF8CCB26B5",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "0b4b14ad9129d1d51793d1dc1864fb4f278e0562a85d91be9fba0eb41890a961"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "ddd7cb87c23a9016ff55ba965c2c66ef8ccb26b5"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-app-example/cam-data/84085ddc-bc10-11ed-9a44-7ef9696e0002.csd",
+      "SPDXID": "SPDXRef-File--cam-app-example-cam-data-84085ddc-bc10-11ed-9a44-7ef9696e0002.csd-9317AC28B80E0F83656B969251B9AE660324F4F2",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "b2bd39d8dd2d723440e9b312b7e2b8073b8d2820e377d369e487592f03574df5"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "9317ac28b80e0f83656b969251b9ae660324f4f2"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-app-example/src/example.c",
+      "SPDXID": "SPDXRef-File--cam-app-example-src-example.c-4B8C84FFA35341D013DD91567C62A8E451F789D3",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "4dd4f60f039db1e4305deb898f98476c2ea8ead8225b0ab04df513c45786405c"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "4b8c84ffa35341d013dd91567c62a8e451f789d3"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./docs/screencast-recordings/FVP_Setup_and_terminals_and_commands.mp4",
+      "SPDXID": "SPDXRef-File--docs-screencast-recordings-FVP-Setup-and-terminals-and-commands.mp4-ECA6CB1590899BE0885E03BE85B36B6D8106B4B3",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "79ab4927529078106ffc5ccdf0e808cfd66c3f990ad83b38906043fb4e68c326"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "eca6cb1590899be0885e03be85b36b6d8106b4b3"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.github/workflows/generate_sbom.yml",
+      "SPDXID": "SPDXRef-File--.github-workflows-generate-sbom.yml-F3C517A8812682C0A291C44B79135676D4074D16",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "67db76d2b10d3b26b0a5d5a980f161399a260dac60688b516bb96fabb6bc3760"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "f3c517a8812682c0a291c44b79135676d4074d16"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.github/workflows/build-reusable_workflow.yaml",
+      "SPDXID": "SPDXRef-File--.github-workflows-build-reusable-workflow.yaml-2B82A21138E22A49A4974C77CC72148502811D37",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "3ac9974b38ce4133a4c81e3f11b226eb8b4160440a7531a954141779fdad3c86"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "2b82a21138e22a49a4974c77cc72148502811d37"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./test/component.py",
+      "SPDXID": "SPDXRef-File--test-component.py-67D5218B42DDBEAA911052EF0F5DB3F98A999C5D",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "69a8c67a66a553a595ca7f267ba0f31d8938cdc450ce598a1b0d59dc037cb4ba"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "67d5218b42ddbeaa911052ef0f5db3f98a999c5d"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./test/fixture/calibration_pack.csc.yml",
+      "SPDXID": "SPDXRef-File--test-fixture-calibration-pack.csc.yml-2E3BED5132B7703A04D82A393AC467EA404A55F5",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "f4cd652b0ab504ab912a015940bb61b0f3446e8b8a2641f0476c959ca122b8d1"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "2e3bed5132b7703a04d82a393ac467ea404a55f5"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/cam_tool/cam_pack.py",
+      "SPDXID": "SPDXRef-File--cam-tool-cam-tool-cam-pack.py-B73CEB94236EB844F3187274186E66BB78742541",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "67ed1f7083c037732f6c978434f74cc23da9c1d97c2a77f8eac34e89de192077"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b73ceb94236eb844f3187274186e66bb78742541"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/test_cam_csel.py",
+      "SPDXID": "SPDXRef-File--cam-tool-test-test-cam-csel.py-7735F74E5A53D0CCF8B020CC6676F0B44C6E0E1F",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "166fb86fdefe504e1e44014d02052cc708465c57e629b2c50476694c93ba8ba6"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "7735f74e5a53d0ccf8b020cc6676f0b44c6e0e1f"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/invalid_mode_name.csc.yml",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-invalid-mode-name.csc.yml-721F11B27E196CFAE16575241E468AD3EDB67EF0",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "b53597120e30cfb8119f4bc549476a4f214e730ff1c129f8eb894ae9550c24f8"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "721f11b27e196cfae16575241e468ad3edb67ef0"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/no_end_entry.csel",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-no-end-entry.csel-42557B34D8D6DF1B31755F521EC2CE886AB9EC07",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ebb172fd749d4734a2da9b887cb72ba2b929d533e4b0566851c03f598776fe84"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "42557b34d8d6df1b31755f521ec2ce886ab9ec07"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/invalid_event_alarm_format.csd",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-invalid-event-alarm-format.csd-9DBB2033B1CB9D7A7BFF6F52902431236248E50A",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "f0b3ee7ad1e961532dda955cc0fb588a39af2ef377d5799e3d950d26198c65e8"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "9dbb2033b1cb9d7a7bff6f52902431236248e50a"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-tool/test/fixture/expected_output.csd",
+      "SPDXID": "SPDXRef-File--cam-tool-test-fixture-expected-output.csd-83CC858D76EC1456512DFFA407E8893E3B3997FF",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "da6c171e6eb22e031686bc5b0c6a4335e50103e84c9e52d38349e1ed316df39c"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "83cc858d76ec1456512dffa407e8893e3b3997ff"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./libcam/include/cam_version.h.in",
+      "SPDXID": "SPDXRef-File--libcam-include-cam-version.h.in-1A3E9FB08FDACEB2EA734ED61ED9A28F7690AFFD",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "566c0ec35a9926bbf821b807c6974ee3769a9a4a9d1d323a38a731dd7b4a29ec"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "1a3e9fb08fdaceb2ea734ed61ed9a28f7690affd"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./libcam/src/cam_csel.h",
+      "SPDXID": "SPDXRef-File--libcam-src-cam-csel.h-63E3FDF626E3EC6B30E49F467EFD152962A448D1",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "535e2d155c16c51a182a1dc59ec55d49674a77892074112792cdb31192217d98"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "63e3fdf626e3ec6b30e49f467efd152962a448d1"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/HEAD",
+      "SPDXID": "SPDXRef-File--.git-HEAD-82AA2E64595C8F99066B7DAD7EC37C90D6BE4E10",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ae72b7960aa39c11c595651a23cdcf512aeb2e4f742710ea0a19e0ef4dba0d40"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "82aa2e64595c8f99066b7dad7ec37c90d6be4e10"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/logs/refs/remotes/origin/US-WS2-06_02",
+      "SPDXID": "SPDXRef-File--.git-logs-refs-remotes-origin-US-WS2-06-02-D19024B151298CB3A0892C04234E92EC1B55708C",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "69259b9487776d024ab42ca039aa5b656aa767ce1edb6f3877d24fba78e73c80"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "d19024b151298cb3a0892c04234e92ec1b55708c"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/hooks/post-commit",
+      "SPDXID": "SPDXRef-File--.git-hooks-post-commit-90E83D48D2E5C47663F21FF5043E31FE56C12278",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "f3eb4d1f62924c09d481a0563a84b158c66eb2feb3431cfdb3e6760aab4d661d"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "90e83d48d2e5c47663f21ff5043e31fe56c12278"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/hooks/prepare-commit-msg.sample",
+      "SPDXID": "SPDXRef-File--.git-hooks-prepare-commit-msg.sample-2584806BA147152AE005CB675AA4F01D5D068456",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "e9ddcaa4189fddd25ed97fc8c789eca7b6ca16390b2392ae3276f0c8e1aa4619"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "2584806ba147152ae005cb675aa4f01d5d068456"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/refs/remotes/origin/US-WS2-06_02",
+      "SPDXID": "SPDXRef-File--.git-refs-remotes-origin-US-WS2-06-02-49CF2A5B3160DFC9B009A4A3C26D978D684FFD3F",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "48862da5a1d0c1f527d4c1f03e9e01553eb24d917a365b505cad24e7db983da5"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "49cf2a5b3160dfc9b009a4a3c26d978d684ffd3f"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/test/src/test_cam_log.c",
+      "SPDXID": "SPDXRef-File--cam-service-test-src-test-cam-log.c-B3FD6CBC0A39BA5AADAE5814E341E525EE6F1ED6",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "e233b2a18ab2c79e5399a97804070b808187e595497fe7eec15ed501b24d80a3"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b3fd6cbc0a39ba5aadae5814e341e525ee6f1ed6"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/test/fixture/84085ddc-bc10-11ed-9a44-7ef9696e9dd5.csd",
+      "SPDXID": "SPDXRef-File--cam-service-test-fixture-84085ddc-bc10-11ed-9a44-7ef9696e9dd5.csd-062A9CDAE020D704F8D4FFE9493B52983CFD23A9",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "2990708e97a5f73078aa65e6691df1efa4bd74a80984357e7c529d2b8ef73f54"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "062a9cdae020d704f8d4ffe9493b52983cfd23a9"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/src/cam_service.h",
+      "SPDXID": "SPDXRef-File--cam-service-src-cam-service.h-593180CC11784FDA23FDC1B1D87169C53FAD4DFE",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "1793e696e522c2fe8ceee22621f31be02867912dc0356c287319c31b567969d6"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "593180cc11784fda23fdc1b1d87169c53fad4dfe"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/src/cam_csd.h",
+      "SPDXID": "SPDXRef-File--cam-service-src-cam-csd.h-0EA0E9DCC515C3EB174BD53BBA5850C41E15161A",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "b8ee393927bc9b86e91af7322f09dcc05900cd55d677006264d0483d84db33fa"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "0ea0e9dcc515c3eb174bd53bba5850c41e15161a"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./Dockerfiles/README.md",
+      "SPDXID": "SPDXRef-File--Dockerfiles-README.md-BBB57ECB6744DCEBB9FF2ED57E4517F1A25449E6",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "69f000a860b9f176ab590c146aa57cae6744a179de633065b1ba90f4a6763bad"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "bbb57ecb6744dcebb9ff2ed57e4517f1a25449e6"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-app-example/cam-data/84085ddc-bc10-11ed-9a44-7ef9696e0000.csd",
+      "SPDXID": "SPDXRef-File--cam-app-example-cam-data-84085ddc-bc10-11ed-9a44-7ef9696e0000.csd-01653994DA51EE6149B9B5B5968EBD43B1D910D7",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "44fa17831d5ff71367faa92b8be948d8ba584fe299e3720a0593c2fc74a6231c"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "01653994da51ee6149b9b5b5968ebd43b1d910d7"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-app-example/src/cmdline.h",
+      "SPDXID": "SPDXRef-File--cam-app-example-src-cmdline.h-5CD15E491354536F4B240848DE00DCD5437330A4",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "1e5b4b0f23e9a74c4e8a244e413663e12a69c8c2d1faeb199b1931bb67740111"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "5cd15e491354536f4b240848de00dcd5437330a4"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/objects/pack/pack-efbf6ffb6330dcbce25c762a37aac52ce143111e.pack",
+      "SPDXID": "SPDXRef-File--.git-objects-pack-pack-efbf6ffb6330dcbce25c762a37aac52ce143111e.pack-02E8DDAFF615B9BD802198374DE31F0A495B75FB",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "4d1fb891be51995fd3e31aa2f9779ca6410b7c23d6c355fed410651ebdaff867"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "02e8ddaff615b9bd802198374de31f0a495b75fb"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/hooks/sendemail-validate.sample",
+      "SPDXID": "SPDXRef-File--.git-hooks-sendemail-validate.sample-74CF1D5415A5C03C110240F749491297D65C4C98",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "44ebfc923dc5466bc009602f0ecf067b9c65459abfe8868ddc49b78e6ced7a92"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "74cf1d5415a5c03c110240f749491297d65c4c98"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./.git/hooks/update.sample",
+      "SPDXID": "SPDXRef-File--.git-hooks-update.sample-730E6BD5225478BAB6147B7A62A6E2AE21D40507",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "8d5f2fa83e103cf08b57eaa67521df9194f45cbdbcb37da52ad586097a14d106"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "730e6bd5225478bab6147b7a62a6e2ae21d40507"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/test/src/test_suite.c",
+      "SPDXID": "SPDXRef-File--cam-service-test-src-test-suite.c-7D0D164A1D20D1D5AEDC862796C823CB87A07C07",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "e3083409fdedeff946d6f16c9c7f0a805f65c0d666e7fbf922d72a97fbf24a6c"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "7d0d164a1d20d1d5aedc862796c823cb87a07c07"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/test/fixture/84085ddc-bc10-11ed-9a44-7ef9696e9dd6.csd",
+      "SPDXID": "SPDXRef-File--cam-service-test-fixture-84085ddc-bc10-11ed-9a44-7ef9696e9dd6.csd-4D5A978F32A79A23E5A50E3516EF6231F96F977D",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "1bf4b2d2a071dd9d7471c3cc5a921b41cfd346359e0868241e2643530662b45c"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "4d5a978f32a79a23e5a50e3516ef6231f96f977d"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/src/cam_socket.c",
+      "SPDXID": "SPDXRef-File--cam-service-src-cam-socket.c-FEDEC13E382F96C1DFAB5807A1191B0E20F8806D",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "d584d5193cb08f444e44677930b152ad768b58d57b6a804226cbec7332378996"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "fedec13e382f96c1dfab5807a1191b0e20f8806d"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/src/cam_log.c",
+      "SPDXID": "SPDXRef-File--cam-service-src-cam-log.c-6BF27E2BE942C4E0317D22B9027A2BF2527C01AB",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "6b1185d8a7e5abfd9776c94d900faeff742861acb5c679fb037d1583f094f5f4"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "6bf27e2be942c4e0317d22b9027a2bf2527c01ab"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-service/src/cam_stream.c",
+      "SPDXID": "SPDXRef-File--cam-service-src-cam-stream.c-B3DC646A5406CFE23BA17CD1C066FABA023998C4",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "e67c0ba7825fcf82b0bffe0d994dd7611a9fa337a42286309cb1e6609d3ff6aa"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b3dc646a5406cfe23ba17cd1c066faba023998c4"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-app-example/cam-data/stream1.csc.yml",
+      "SPDXID": "SPDXRef-File--cam-app-example-cam-data-stream1.csc.yml-9BFED0F18110A8BB2A6A42EECACA79CDC234C7D8",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "5db7d40473e5ca1fd1dd394ac3319daabd2e8f97e0b92b58910c8134ba287f41"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "9bfed0f18110a8bb2a6a42eecaca79cdc234c7d8"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./cam-app-example/src/config.h",
+      "SPDXID": "SPDXRef-File--cam-app-example-src-config.h-9C6DBBA383998473A62FECD67CE030FE8FDF2444",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "905616acbf70339216fe9cbeaf65850f4d4a61eee38a47dcd6dbbce897e5a56c"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "9c6dbba383998473a62fecd67ce030fe8fdf2444"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION"
+    }
+  ],
+  "packages": [
+    {
+      "name": "sphinx",
+      "SPDXID": "SPDXRef-Package-87749F3F5444B22B14A14E3607A49BA23BCDAEDF24C51964277B625FD9FD4967",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "copyrightText": "NOASSERTION",
+      "versionInfo": "6.1.3",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:pypi/sphinx@6.1.3"
+        }
+      ],
+      "supplier": "NOASSERTION"
+    },
+    {
+      "name": "pytest",
+      "SPDXID": "SPDXRef-Package-C99E2E1E6C0E9A26D42002AD18B5C4EC3DD2F09BF57BDC6A772477CFBC5B33D1",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "copyrightText": "NOASSERTION",
+      "versionInfo": "7.1.2",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:pypi/pytest@7.1.2"
+        }
+      ],
+      "supplier": "NOASSERTION"
+    },
+    {
+      "name": "readthedocs-sphinx-search",
+      "SPDXID": "SPDXRef-Package-3F012714C432ACDFE4FC4261380361E90457B9E6DA4933C8205A749D16624AD3",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "copyrightText": "NOASSERTION",
+      "versionInfo": "0.3.2",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:pypi/readthedocs-sphinx-search@0.3.2"
+        }
+      ],
+      "supplier": "NOASSERTION"
+    },
+    {
+      "name": "sphinxcontrib-googleanalytics",
+      "SPDXID": "SPDXRef-Package-501BDE8C2898B8F7C7CE89A8E40E4EE4137C22696CD458B85DDC6F4C505B5C05",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "copyrightText": "NOASSERTION",
+      "versionInfo": "0.4",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:pypi/sphinxcontrib-googleanalytics@0.4"
+        }
+      ],
+      "supplier": "NOASSERTION"
+    },
+    {
+      "name": "sphinx-rtd-theme",
+      "SPDXID": "SPDXRef-Package-4DEA190FC8CE8EE0F406A9FF1F755BA738B18B7A986FF9D7E7F3731248E81E75",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "copyrightText": "NOASSERTION",
+      "versionInfo": "2.0.0",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:pypi/sphinx-rtd-theme@2.0.0"
+        }
+      ],
+      "supplier": "NOASSERTION"
+    },
+    {
+      "name": "sphinx-substitution-extensions",
+      "SPDXID": "SPDXRef-Package-25A88B0E02EA9C9A3AF567240D2E9383B7A0B6C2B0D847431A58F42A9C2D6779",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "copyrightText": "NOASSERTION",
+      "versionInfo": "2022.2.16",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:pypi/sphinx-substitution-extensions@2022.2.16"
+        }
+      ],
+      "supplier": "NOASSERTION"
+    },
+    {
+      "name": "sphinx-copybutton",
+      "SPDXID": "SPDXRef-Package-F891BD098C2683819984852B8A47264307A6F37C7CB948CEA205390A27FED40D",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "copyrightText": "NOASSERTION",
+      "versionInfo": "0.5.2",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:pypi/sphinx-copybutton@0.5.2"
+        }
+      ],
+      "supplier": "NOASSERTION"
+    },
+    {
+      "name": "pyyaml",
+      "SPDXID": "SPDXRef-Package-608734958F785BCA948551853649C7FC98B52E5D2060EC426F90714C5A70228D",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "copyrightText": "NOASSERTION",
+      "versionInfo": "6.0",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:pypi/pyyaml@6.0"
+        }
+      ],
+      "supplier": "NOASSERTION"
+    },
+    {
+      "name": "from_root",
+      "SPDXID": "SPDXRef-Package-997BB0F681869CA98D5667676CD5B68622673C2FEF7DC8A74C4063DC206A7218",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "copyrightText": "NOASSERTION",
+      "versionInfo": "1.3.0",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:pypi/from-root@1.3.0"
+        }
+      ],
+      "supplier": "NOASSERTION"
+    },
+    {
+      "name": "breathe",
+      "SPDXID": "SPDXRef-Package-480871C937AB17B2CA00697B94806F3B668E9C726D662774832FD26A33E9C973",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "copyrightText": "NOASSERTION",
+      "versionInfo": "4.35.0",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:pypi/breathe@4.35.0"
+        }
+      ],
+      "supplier": "NOASSERTION"
+    },
+    {
+      "name": "im-customers-arm/arm-critical-app-monitoring",
+      "SPDXID": "SPDXRef-RootPackage",
+      "downloadLocation": "NOASSERTION",
+      "packageVerificationCode": {
+        "packageVerificationCodeValue": "4bf01b9dc20a0976e8fc4b375d67dad99aa9d32a"
+      },
+      "filesAnalyzed": true,
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoFromFiles": [
+        "NOASSERTION"
+      ],
+      "licenseDeclared": "NOASSERTION",
+      "copyrightText": "NOASSERTION",
+      "versionInfo": "1.0.0",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:swid/OwnerName/sbom.infomagnus.com/im-customers-arm%2Farm-critical-app-monitoring@1.0.0?tag_id=aaf7deb9-4778-491e-9fa4-d30aab267589"
+        }
+      ],
+      "supplier": "Organization: OwnerName",
+      "hasFiles": [
+        "SPDXRef-File--cam-app-example-src-config.h-9C6DBBA383998473A62FECD67CE030FE8FDF2444",
+        "SPDXRef-File--cam-app-example-cam-data-stream1.csc.yml-9BFED0F18110A8BB2A6A42EECACA79CDC234C7D8",
+        "SPDXRef-File--cam-service-src-cam-stream.c-B3DC646A5406CFE23BA17CD1C066FABA023998C4",
+        "SPDXRef-File--cam-service-src-cam-log.c-6BF27E2BE942C4E0317D22B9027A2BF2527C01AB",
+        "SPDXRef-File--cam-service-src-cam-socket.c-FEDEC13E382F96C1DFAB5807A1191B0E20F8806D",
+        "SPDXRef-File--cam-service-test-fixture-84085ddc-bc10-11ed-9a44-7ef9696e9dd6.csd-4D5A978F32A79A23E5A50E3516EF6231F96F977D",
+        "SPDXRef-File--cam-service-test-src-test-suite.c-7D0D164A1D20D1D5AEDC862796C823CB87A07C07",
+        "SPDXRef-File--.git-hooks-update.sample-730E6BD5225478BAB6147B7A62A6E2AE21D40507",
+        "SPDXRef-File--.git-hooks-sendemail-validate.sample-74CF1D5415A5C03C110240F749491297D65C4C98",
+        "SPDXRef-File--.git-objects-pack-pack-efbf6ffb6330dcbce25c762a37aac52ce143111e.pack-02E8DDAFF615B9BD802198374DE31F0A495B75FB",
+        "SPDXRef-File--cam-app-example-src-cmdline.h-5CD15E491354536F4B240848DE00DCD5437330A4",
+        "SPDXRef-File--cam-app-example-cam-data-84085ddc-bc10-11ed-9a44-7ef9696e0000.csd-01653994DA51EE6149B9B5B5968EBD43B1D910D7",
+        "SPDXRef-File--Dockerfiles-README.md-BBB57ECB6744DCEBB9FF2ED57E4517F1A25449E6",
+        "SPDXRef-File--cam-service-src-cam-csd.h-0EA0E9DCC515C3EB174BD53BBA5850C41E15161A",
+        "SPDXRef-File--cam-service-src-cam-service.h-593180CC11784FDA23FDC1B1D87169C53FAD4DFE",
+        "SPDXRef-File--cam-service-test-fixture-84085ddc-bc10-11ed-9a44-7ef9696e9dd5.csd-062A9CDAE020D704F8D4FFE9493B52983CFD23A9",
+        "SPDXRef-File--cam-service-test-src-test-cam-log.c-B3FD6CBC0A39BA5AADAE5814E341E525EE6F1ED6",
+        "SPDXRef-File--.git-refs-remotes-origin-US-WS2-06-02-49CF2A5B3160DFC9B009A4A3C26D978D684FFD3F",
+        "SPDXRef-File--.git-hooks-prepare-commit-msg.sample-2584806BA147152AE005CB675AA4F01D5D068456",
+        "SPDXRef-File--.git-hooks-post-commit-90E83D48D2E5C47663F21FF5043E31FE56C12278",
+        "SPDXRef-File--.git-logs-refs-remotes-origin-US-WS2-06-02-D19024B151298CB3A0892C04234E92EC1B55708C",
+        "SPDXRef-File--.git-HEAD-82AA2E64595C8F99066B7DAD7EC37C90D6BE4E10",
+        "SPDXRef-File--libcam-src-cam-csel.h-63E3FDF626E3EC6B30E49F467EFD152962A448D1",
+        "SPDXRef-File--libcam-include-cam-version.h.in-1A3E9FB08FDACEB2EA734ED61ED9A28F7690AFFD",
+        "SPDXRef-File--cam-tool-test-fixture-expected-output.csd-83CC858D76EC1456512DFFA407E8893E3B3997FF",
+        "SPDXRef-File--cam-tool-test-fixture-invalid-event-alarm-format.csd-9DBB2033B1CB9D7A7BFF6F52902431236248E50A",
+        "SPDXRef-File--cam-tool-test-fixture-no-end-entry.csel-42557B34D8D6DF1B31755F521EC2CE886AB9EC07",
+        "SPDXRef-File--cam-tool-test-fixture-invalid-mode-name.csc.yml-721F11B27E196CFAE16575241E468AD3EDB67EF0",
+        "SPDXRef-File--cam-tool-test-test-cam-csel.py-7735F74E5A53D0CCF8B020CC6676F0B44C6E0E1F",
+        "SPDXRef-File--cam-tool-cam-tool-cam-pack.py-B73CEB94236EB844F3187274186E66BB78742541",
+        "SPDXRef-File--test-fixture-calibration-pack.csc.yml-2E3BED5132B7703A04D82A393AC467EA404A55F5",
+        "SPDXRef-File--documentation--static-css-custom.css-24A745E0C2B3A8C5DEBD4340571F895AAC3A96F2",
+        "SPDXRef-File--documentation-release-notes.rst-828594325069BC7100CB59B7413DA26D7190CD15",
+        "SPDXRef-File--.gitignore-8A015813F7BDBDBB99B4286A32A03D41F2F803BF",
+        "SPDXRef-File--CMakeLists.txt-35A4BFDCBEAC91A1CA69AE2971DD7742A3341EE0",
+        "SPDXRef-File--docs-screencast-recordings-FVP-Setup-and-terminals-and-commands.mp4-ECA6CB1590899BE0885E03BE85B36B6D8106B4B3",
+        "SPDXRef-File--cam-app-example-src-example.c-4B8C84FFA35341D013DD91567C62A8E451F789D3",
+        "SPDXRef-File--cam-app-example-cam-data-84085ddc-bc10-11ed-9a44-7ef9696e0002.csd-9317AC28B80E0F83656B969251B9AE660324F4F2",
+        "SPDXRef-File--scripts-lint-strictdoc-traceability.py-DDD7CB87C23A9016FF55BA965C2C66EF8CCB26B5",
+        "SPDXRef-File--cam-service-src-cam-fault-driver-itf.h-B1BFF13B18EA906B194D5601C2F2C621BACFF032",
+        "SPDXRef-File--cam-service-src-cam-cmdline.h-435C56EE8A65A388D42B1FBF03CC824AE3CE3DB2",
+        "SPDXRef-File--cam-service-test-fixture-84085ddc-bc10-11ed-9a44-7ef9696e9dd9.csd-73C7E4D2BF01A74515C7AD0D73A7A4CCAC333D0D",
+        "SPDXRef-File--cam-service-test-src-test-cam-config.c-3A4770126BF91DD692B1134A7B9C7EB2BFD15DDA",
+        "SPDXRef-File--.git-hooks-post-merge-02D6A0E420A63C99AA9ACD43445F0D8DC99E35E3",
+        "SPDXRef-File--.git-hooks-pre-commit.sample-8093D68E142DB52DCAB2215E770BA0BBE4CFBF24",
+        "SPDXRef-File--.git-hooks-pre-push-6145042684084DFE68CED3427E8F0A7671276831",
+        "SPDXRef-File--.git-FETCH-HEAD-3C962B3AE8B546A1EF13FF494C5A9AFF88EB870B",
+        "SPDXRef-File--cam-uuid-test-src-test-cam-uuid.c-068016D85D9E746E6CDA81B42A760798CE03BEE1",
+        "SPDXRef-File--libcam-test-fixture-expected-output.csel-EF6628FAB17D7E0F5F566DBE434362BDB3F228DF",
+        "SPDXRef-File--cam-tool-test-fixture-no-meta-name.csc.yml-A8E9876D88DE9C60EB7618F1B2C5D170FA16EAB2",
+        "SPDXRef-File--cam-tool-test-fixture-expected-msg-output-1-708DB2D675705C43916EA51990AA853EBB69937D",
+        "SPDXRef-File--cam-tool-test-fixture-invalid-message-size.msg-rcv-3339B43BB254748746D13FB535E8FED71A0CF965",
+        "SPDXRef-File--cam-tool-test-fixture-invalid-name.csc.yml-97DD33F4CC67022B25DB195EA76742D1D69AB4CE",
+        "SPDXRef-File--cam-tool-test-fixture-invalid-mode-id.csc.yml-E5B5755AB1159298FC475E58579FB0F69622CB49",
+        "SPDXRef-File--cam-tool-test-test-cam-csc.py-63FD5D70BB8D5AE1B0AC26D8937F9EC6249D2967",
+        "SPDXRef-File--cam-tool-cam-tool---init--.py-99CC0AD65EE34E2C19C7BBE1B2E98783F60C5F26",
+        "SPDXRef-File--test-fixture-calibration-analyze.csel-3329494445A06C421C84B682F60CF28FEF665F5A",
+        "SPDXRef-File--test-test-static-config.py-47FF9981FC9B1718C94E13C3E0E5C15DAA0F6549",
+        "SPDXRef-File--.github-workflows-kas-auto-build.yml-BCA65F4579DB4B6424E88E7184147451015AC94C",
+        "SPDXRef-File--.github-workflows-automated-kas-setup.yml-13233442371BD36EEFAB2CFC0DD53DEE3591EA34",
+        "SPDXRef-File--docs-screencast-recordings-CAMDemo-Automation-results.mp4-03D57D5CE2FC70D330C1757A0CEFFB1C9924E3FB",
+        "SPDXRef-File--docs-strictdoc-evidence-EVID-001-temporal-fault-detection.txt-1375D89BF1BF435171B2EAE4334E24781601E5BB",
+        "SPDXRef-File--docs-strictdoc-demo-script.md-A409B1CA88D6E07E575411B260D4BE6BBAD680A8",
+        "SPDXRef-File--docs-strictdoc-cam-fusa.sgra-F51F528801ACABD35CD92B4B2824F6419FCF78B6",
+        "SPDXRef-File--docs-demos-project-gearshift-demo-scenario-unittests.md-2048CB17747D80661512FEF0560836E15259387E",
+        "SPDXRef-File--documentation-images-fault-injection.svg-85911D560DBF135B6635C5E669BB6A0571E69398",
+        "SPDXRef-File--cam-app-example-cam-data-84085ddc-bc10-11ed-9a44-7ef9696e0001.csd-CA32F5D6E9EE31C51FD93739834F7FF67E0AAA93",
+        "SPDXRef-File--cam-app-example-CMakeLists.txt-7CE727E657055E814EA31C91E9C3C4D8525129EB",
+        "SPDXRef-File--cam-service-src-cam-config.h-983C9B066BDEDEF0B10DF31CCB8B390CC0D5B0A5",
+        "SPDXRef-File--cam-service-src-cam-stream.h-07CC268E59C3E5286D0EEF70E55D50D18B40B82E",
+        "SPDXRef-File--cam-service-test-fixture-84085ddc-bc10-11ed-9a44-7ef9696e9dd7.csd-CBE5C5E17960713783A419D122433B548A78E933",
+        "SPDXRef-File--cam-service-test-src-test-cam-socket.c-DC3E53359233F8D64E9717A909A03EFC9307CC92",
+        "SPDXRef-File--cam-service-test-CMakeLists.txt-6EF2225B24DA4CCBA84F68EA89D96503E208C29D",
+        "SPDXRef-File--.git-hooks-pre-merge-commit.sample-04C64E58BC25C149482ED45DBD79E40EFFB89EB7",
+        "SPDXRef-File--.git-hooks-post-update.sample-B614C2F63DA7DCA9F1DB2E7ADE61EF30448FC96C",
+        "SPDXRef-File--.git-objects-pack-pack-efbf6ffb6330dcbce25c762a37aac52ce143111e.rev-DCE4E2D730A59CE9DB954159E090AE4178CF6CC9",
+        "SPDXRef-File--.git-shallow-49CF2A5B3160DFC9B009A4A3C26D978D684FFD3F",
+        "SPDXRef-File--cam-uuid-test-src-test-suite.c-A29C11054F5F209D10963CEDB0018D9D561AE899",
+        "SPDXRef-File--libcam-test-src-test-suite.h-30E60F13DCD57065C8F3206914794786E9AEBFFF",
+        "SPDXRef-File--cam-tool-test-fixture-no-meta.csc.yml-51A03E2DD226DE200EAB9B90FD5D85A9CB0BC05A",
+        "SPDXRef-File--cam-tool-test-fixture-no-padding-bytes.csel-6022672C7971BE526F9CBB4B7FD4E6F3467DCF04",
+        "SPDXRef-File--cam-tool-test-fixture-invalid-command-id.msg-rcv-6892044A8100A5425A569EB2127A53914DBED544",
+        "SPDXRef-File--cam-tool-test-fixture-invalid-entry-type.csel-47CEA57F0303B2C20AC64884262A907A1B832263",
+        "SPDXRef-File--cam-tool-test-fixture-inconsistent-uuid.msg-rcv-F51A3E3AA4A405B281EE23C4A5DA4BACBE64C8D5",
+        "SPDXRef-File--cam-tool-test-test-cam-csd.py-A8EF645A845E0671A682E6EAA816F20728914CC4",
+        "SPDXRef-File--cam-tool-cam-tool-cam-analyze.py-B7F2804A15B69FE382C7D56ED940C4691B7846BB",
+        "SPDXRef-File--test-fixture-config-deploy-valid.csd-83CC858D76EC1456512DFFA407E8893E3B3997FF",
+        "SPDXRef-File--test-test-calibration.py-C89FCFA1CE881D2D7D1263C88C3A962D2DAF91D1",
+        "SPDXRef-File--.github-workflows-sbom-exper2.yml-E3562936495B7045E97B5BE23FFCC104EB1C9484",
+        "SPDXRef-File--.github-workflows-super-linter.yaml-A4D9459C3877B00E6FA98054D10250ADA592E960",
+        "SPDXRef-File--docs-strictdoc-evidence-EVID-012-ci-sbom-artifact.txt-BE4E7E0B040AE85FA02914991445D29B27537383",
+        "SPDXRef-File--docs-strictdoc-evidence-EVID-004-start-to-first-event-timeout.txt-50BDFB19E32CA59800505F1C60530B506A4F5264",
+        "SPDXRef-File--docs-strictdoc-EXPORT-INSTRUCTIONS.md-2501658D15C120630C7832F07E05942BD02F9A92",
+        "SPDXRef-File--docs-strictdoc-08-evidence-log.sdoc-C7EAE589EDA66EF750173C9EE3219B1351A89694",
+        "SPDXRef-File--docs-demos-project-gearshift-demo-scenario-copilot.md-DADE9124CCA3B182500FEDF4E21045D3F2D37092",
+        "SPDXRef-File--documentation-manual-index.rst-6000F7F3027086ED04B6D2CE5B649AE2A0CE8DDE",
+        "SPDXRef-File--cam-app-example-cam-data-84085ddc-bc10-11ed-9a44-7ef9696e0003.csd-6F6ACA5EE68C3C576D862B5C766060F53E2EA828",
+        "SPDXRef-File--Dockerfiles-cam-image-Dockerfile-9B16B2BA2DD4FAEE61BF68D3991DB04B59FAF302",
+        "SPDXRef-File--cam-service-src-cam-fault.c-062A76F5FDECA2B53E0632CDF727B831F1DCA408",
+        "SPDXRef-File--cam-service-src-cam-log.h-AD17683053FB4982EDF858A8C96A0F7244B0D077",
+        "SPDXRef-File--cam-service-test-fixture-84085ddc-bc10-11ed-9a44-7ef9696e9dd3.csd-AE0F24D8FAB62DD878E6409B64F97A026EC7126F",
+        "SPDXRef-File--cam-service-test-src-test-cam-stream.c-B1E0B2B807A8E108C8DB45C86745A51AD9E84A97",
+        "SPDXRef-File--.git-refs-heads-US-WS2-06-02-49CF2A5B3160DFC9B009A4A3C26D978D684FFD3F",
+        "SPDXRef-File--.git-hooks-post-checkout-34CCA5E573F14E1C8F36C447FD5005D7D93EBEA7",
+        "SPDXRef-File--.git-hooks-fsmonitor-watchman.sample-0EC0EC9AC11111433D17EA79E0AE8CEC650DCFA4",
+        "SPDXRef-File--.git-logs-refs-heads-US-WS2-06-02-90B2D3944039C28E9D0EA7BDD49860523DEC12A1",
+        "SPDXRef-File--.git-index-3C98A6454DB89BA34127FA139BA0E5DD4F3E1AEE",
+        "SPDXRef-File--cam-uuid-CMakeLists.txt-429DF1FA2038DECE612F82FBE72D8A1D0DD1DB7A",
+        "SPDXRef-File--libcam-include-cam.h-7553478E86CC65768C7F2062779288069F681AE7",
+        "SPDXRef-File--cam-tool-test-fixture-invalid-entry-format.csel-093D75799B926A2DF78DD3A00A092EFCF9974EEE",
+        "SPDXRef-File--cam-tool-test-fixture-no-alarms.csc.yml-F6D3CA69987F234B05AEC738CC90E110688804CD",
+        "SPDXRef-File--cam-tool-test-fixture-out-of-period-event-id.csel-B0C7D1F868D84A1BB4EAABD3486A15B1CBCC0C8A",
+        "SPDXRef-File--cam-tool-test-fixture-non-periodic-event-entry.csel-CE978035A715CF666F14200CDB14A0DFA3897A29",
+        "SPDXRef-File--cam-tool-test-fixture-valid.csel-3329494445A06C421C84B682F60CF28FEF665F5A",
+        "SPDXRef-File--cam-tool-cam-tool-cam-tool-run.py-B10839D60E38CC0EC8953A8D10B1DC7824738A04",
+        "SPDXRef-File--test-fixture-99085ddc-bc10-11ed-9a44-7ef9696e0001.csc.yml-66A179E3CC4CA4E7A972F77C65988C623B4FB208",
+        "SPDXRef-File--test-fixture-calibration-invalid-analyze.csel-678DCFAE77E7B59A602C5B755A6028A01BAF9627",
+        "SPDXRef-File--.github-workflows-corellium-saas.yaml-2331229D101363C470F8F1EAE01639C27D709AC7",
+        "SPDXRef-File--.github-workflows-Kronos.yaml-93C30B82E49670E235C9947A73DE21546C57C382",
+        "SPDXRef-File--docs-screencast-recordings-TMUX-and-Installation.mp4-94759FDB0D2B2BDC81A54177857B633B58ECF40A",
+        "SPDXRef-File--docs-strictdoc-evidence-EVID-006-csc-validation-and-conversion.txt-D554A42A6064AAEAEC0441B452440D93314A97CF",
+        "SPDXRef-File--docs-strictdoc-05-swa-cam.sdoc-9F15A3AA7EEB2F99FD3A031DB26DA9C2D89E4870",
+        "SPDXRef-File--docs-strictdoc-04-ssr-cam.sdoc-EE9983D01C412C9F73925C799C391C2920003330",
+        "SPDXRef-File--docs-demos-cicd.png-1CC22BC2C252E9668F878003ACD10A0204CCA471",
+        "SPDXRef-File--documentation-images-event-interval.svg-121EC6E3C791FDF92DF651A84CAC062D0C328466",
+        "SPDXRef-File--documentation-manual-file-csd.rst-BEF0A366BD190B3C9987FE6596FCCFBB3879EB3B",
+        "SPDXRef-File--docs-strictdoc-evidence-EVID-002-out-of-order-event-detection.txt-F6D6BB3A3BD6BC9CC5495DBB440866A482517F37",
+        "SPDXRef-File--docs-strictdoc-07-test-specs.sdoc-801B381EADC023B6227BFA3A4E0CCAD2C9C9DCC0",
+        "SPDXRef-File--docs-strictdoc-03-tsc-lite.sdoc-0A6007ADC4AD1CD912F4A51887D411536CA3AAE6",
+        "SPDXRef-File--docs-demos-IntegrationDoc.md-9253A9105C5600331DA5F412467EBC68670DB799",
+        "SPDXRef-File--documentation-images-cam-timings.svg-212AEA7CE6959DCD5A9AD861693FA86FDA5862B0",
+        "SPDXRef-File--documentation-manual-message-protocol.rst-81BF4DD1113F1BFA114B3C24F487C25EC1DE411A",
+        "SPDXRef-File--cam-app-example-cam-data-stream0.csc.yml-05B5987F38DC99E6B363989912B8DB3E92227614",
+        "SPDXRef-File--Dockerfiles-cam-image-zephyr-Dockerfile-A497A8BC79C5A8AF188A18C5C466C70583FE4EDD",
+        "SPDXRef-File--cam-service-src-cam-fault.h-8A8573270E076ECE7A088118CB9DF4FA18C1B0CB",
+        "SPDXRef-File--cam-service-src-cam-cmdline.c-8AAD45DCCC0F09F9D4653920E6E3BEC1B9B239EB",
+        "SPDXRef-File--cam-service-test-fixture-84085ddc-bc10-11ed-9a44-7ef9696e9dd8.csd-4653DBEDB4C09D685AC8662927D0CFB1A48A9BF1",
+        "SPDXRef-File--cam-service-test-src-test-cam-fault.c-C794D099ACB222BD254970C4B46A1B18DBDC1BE5",
+        "SPDXRef-File--cam-service-CMakeLists.txt-A344D3B230198DDB4E746D5D6294A24E55E3F590",
+        "SPDXRef-File--.git-hooks-applypatch-msg.sample-4DE88EB95A5E93FD27E78B5FB3B5231A8D8917DD",
+        "SPDXRef-File--.git-hooks-pre-receive.sample-705A17D259E7896F0082FE2E9F2C0C3B127BE5AC",
+        "SPDXRef-File--.git-info-exclude-C879DF015D97615050AFA7B9641E3352A1E701AC",
+        "SPDXRef-File--.git-config-627B8DA189E9287636A48F52793E0B016B7296B8",
+        "SPDXRef-File--cam-uuid-include-cam-uuid.h-FF38CAD2730F332982C8A7801C328D3D27AB18ED",
+        "SPDXRef-File--libcam-test-CMakeLists.txt-6D2DD90E4E04C809BF7701766993E69468AB5D1D",
+        "SPDXRef-File--cam-tool-test-fixture-invalid-sequence-id.csel-7918B1E5EA8F47236E74EA21438F97F66012F51E",
+        "SPDXRef-File--cam-tool-test-fixture-invalid-protocol-version.msg-rcv-3F7A1905CD1D0B9B8C774C8E03363A123849E198",
+        "SPDXRef-File--cam-tool-test-fixture-invalid-entry-sequence.csel-F71D87F20E75D641F4302E4D6AC4056CEEDAD090",
+        "SPDXRef-File--cam-tool-test-fixture-error-case.msg-rcv-6BD54C8B87265DCC3D62590E8CFCC543F713343D",
+        "SPDXRef-File--cam-tool-test-fixture-invalid-uuid.csc.yml-497E5EC9D9ABDC9F0B43CA943F8BD4208E5E8980",
+        "SPDXRef-File--cam-tool-cam-tool-cam-csc.py-BA3F1CA77C45DCCD8FCC35CD35C14324C74E4A5D",
+        "SPDXRef-File--cam-tool-pyproject.toml-69538DF8B7CA45392165C8DE6931B98B5451BEDB",
+        "SPDXRef-File--test-fixture-config-deploy-invalid.csd-3329494445A06C421C84B682F60CF28FEF665F5A",
+        "SPDXRef-File--.github-workflows-build-cam-app.yaml-E5CE4255BDEF6D765156DEBF52271E284A8AD22A",
+        "SPDXRef-File--.github-workflows-build-cam-app-exper.yml-92C4B65CEA547955179D00C1E31DC235ED7D971E",
+        "SPDXRef-File--docs-screencast-recordings-ScreencastUpdated.mp4-5A1C1A319126ED0718432FC79534069491EBBDA3",
+        "SPDXRef-File--docs-strictdoc-evidence-EVID-010-libcam-protocol-sequence.txt-EA033D404B5307566EF0D8C3CC6609D742428803",
+        "SPDXRef-File--docs-strictdoc-evidence-EVID-007-deploy-message-chunking.txt-7B87AFED92003513E09735899EBE88E7B795D704",
+        "SPDXRef-File--docs-strictdoc-02-fsc-lite.sdoc-441C5B9C5D87EF26CED32BC31FFDC5EECB6D5015",
+        "SPDXRef-File--docs-demos-project-gearshift-demo-scenario-integrationtests.md-96ABDE387BBCF05CED314CA2BB066EADB5D2E275",
+        "SPDXRef-File--documentation-cmake-FindSPHINX.cmake-523D03A6BBE1572A7935FFBC0473978AD99CE48A",
+        "SPDXRef-File--documentation-manual-file-csc.rst-A2DD41175AABDAD3A7D86428A646B514ACF6A927",
+        "SPDXRef-File--documentation-license-link.rst-6E2E46EF9CA8EF0F8BBC0A3011BF6DF1B6578277",
+        "SPDXRef-File--.codeclimate.yml-B2CEE30FD5E2C2BB525F0019546094B4F2C6921A",
+        "SPDXRef-File--.readthedocs.yaml-71E0A36B7643334D48EAD0A3C865120841629A5C",
+        "SPDXRef-File--.clang-format-6B5CD29FB1194B199BF9F6C37BF9234CF43E63C6",
+        "SPDXRef-File--documentation-index.rst-60ED03295AA86DCA8A81B1FC8A03973B0D59ED09",
+        "SPDXRef-File--Kconfig-F465C8DC8C1F3062054BE5523F07B9EC3E6851D8",
+        "SPDXRef-File--.gitattributes-B6143C97D3D1DD843B6D533BD4847C1A81E2D756",
+        "SPDXRef-File--documentation-conf.py-032B36C380275C8ECE8607D9A1D01E7196A799A9",
+        "SPDXRef-File--prj.conf-06A4F39165FD4E56763CA2FCA64B0EF8954C3CE1",
+        "SPDXRef-File--kas-build.yml-B429194A86D4E5BBFD6713A8BF982A09643196A8",
+        "SPDXRef-File--documentation-overview.rst-58549620111F13EF590623AF4C84BB521818DAEA",
+        "SPDXRef-File--.dictionary-291994BFD92EAE2A2BA5C7A0269B3F98E2909142",
+        "SPDXRef-File--license.rst-D9C974B17783DCD346D897432773DD17C231E26A",
+        "SPDXRef-File--documentation-development-coding-style.rst-695E8BCBC4E82D3C403A30B9C2F409DFB8BB6FA3",
+        "SPDXRef-File--documentation-getting-started.rst-65E3C81C64BFD1C2E85F65DCBE06B47D76BB987C",
+        "SPDXRef-File--.gitmodules-2D3388FE54BDC635318EE07D60AD92DC4FAFCDA4",
+        "SPDXRef-File--SECURITY.md-FA533283215D0BA141A7A28AC0D4FDC8089E3F0B",
+        "SPDXRef-File--test-component.py-67D5218B42DDBEAA911052EF0F5DB3F98A999C5D",
+        "SPDXRef-File--.github-workflows-build-reusable-workflow.yaml-2B82A21138E22A49A4974C77CC72148502811D37",
+        "SPDXRef-File--.github-workflows-generate-sbom.yml-F3C517A8812682C0A291C44B79135676D4074D16",
+        "SPDXRef-File--cam-app-example-cam-data-stream3.csc.yml-CAF7B6B3E42354802A33581855DD5EBE8B0FF855",
+        "SPDXRef-File--cam-service-src-cam-socket.h-DB7379FF8E36074013239786061C8128A9F12175",
+        "SPDXRef-File--cam-service-src-cam-config.c-A33EF64845B1C4765FAF99DB96CB96A4CCA9DD2E",
+        "SPDXRef-File--cam-service-test-fixture-84085ddc-bc10-11ed-9a44-7ef9696e9dd4.csd-93CEBCFF20A0D6BD76387C9B31399335CA1753CF",
+        "SPDXRef-File--cam-service-test-src-posix-call-utils.h-5A708BD5310DBEECE6A6080441282457718E7B05",
+        "SPDXRef-File--cam-service-common-cam-message.h-5A3730C811AD621A212740FD29F45B63EA8C64AD",
+        "SPDXRef-File--.git-hooks-pre-rebase.sample-288EFDC0027DB4CFD8B7C47C4AEDDBA09B6DED12",
+        "SPDXRef-File--.git-hooks-pre-applypatch.sample-F208287C1A92525DE9F5462E905A9D31DE1E2D75",
+        "SPDXRef-File--.git-objects-pack-pack-efbf6ffb6330dcbce25c762a37aac52ce143111e.idx-51672A6BBA16CCE665A16362BDE68392DB84FDCF",
+        "SPDXRef-File--.git-config.worktree-CA859A5B32728E6B456D4E5011D9011BB638AC1C",
+        "SPDXRef-File--cam-uuid-test-CMakeLists.txt-73529D565EAB077BE2941022E5A881541529D7F0",
+        "SPDXRef-File--libcam-test-src-test-suite.c-A1AF64B2AAEF31D7E5E03BC1A17A7EF16465A838",
+        "SPDXRef-File--cam-tool-test-fixture-unexpected-status-type.msg-rcv-C4E1A68A47741430037C51F1CADD5E2F80DEBBE3",
+        "SPDXRef-File--cam-tool-test-fixture-file-size-overflow.csd-70F9465FE4A5A7C41EACF00DAC3B9F61002C519C",
+        "SPDXRef-File--cam-tool-test-fixture-invalid-version.csc.yml-08BA3ADE3C14F15129F6165C47C429BE76674946",
+        "SPDXRef-File--cam-tool-test-fixture-no-version.csc.yml-64AF7B974DCB6CD16359FD34F6DA3A7B598FA0D2",
+        "SPDXRef-File--cam-tool-test-fixture-invalid-timeout.csc.yml-F29793EED18438DC1BFD6B3D3356FAA3B951657B",
+        "SPDXRef-File--cam-tool-cam-tool-cam-deploy.py-5098F7AA4441CBEB1D52C9F017999C43C6D055A8",
+        "SPDXRef-File--cam-tool-cam-tool-cam-csd.py-6227BB362E49D0D96E6610527B3A5299CE7F4766",
+        "SPDXRef-File--test-fixture-99085ddc-bc10-11ed-9a44-7ef9696e0000.csd-8CAD6A0C5B6F171CF8F0AF0BE03FB2070C8CD7C0",
+        "SPDXRef-File--.github-workflows-correlium.yaml-E233632E89F7F03755E9D2F8A4B16317E65B9AAE",
+        "SPDXRef-File--.github-workflows-code-coverage.yaml-96397A8E74EE740B15453C4EDF094515B5BF8CBD",
+        "SPDXRef-File--.github-dependabot.yml-3D2B68A042CA883BE6F12D33A24FABD3931FBC73",
+        "SPDXRef-File--docs-strictdoc-evidence-EVID-005-event-before-start-fault.txt-F738A8DB8ECFF9C604D31E2A783B2DFC48494F54",
+        "SPDXRef-File--docs-strictdoc-evidence-EVID-003-sequence-mismatch-fault.txt-7ACA608B64600100B9F5F53AB750912C0D34CC58",
+        "SPDXRef-File--docs-strictdoc-strictdoc.toml-57DD715261F13F14197A237D5C44C21C35268147",
+        "SPDXRef-File--docs-strictdoc-00-item-definition.sdoc-B33028A11A42301C6E384B008EA93DAE78DB29B9",
+        "SPDXRef-File--docs-.DS-Store-3FDBB98C715247247D3549E4E622E97F29C6E369",
+        "SPDXRef-File--documentation-manual-libcam-api.rst-02E25925E274224DB87DBA00762F95D86D3F72F5",
+        "SPDXRef-File--cam-app-example-src-cmdline.c-DD946FF294E3285DB10F38DCAFF0C0DEF2D2C255",
+        "SPDXRef-File--cam-app-example-cam-data-stream2.csc.yml-E9A09C044562B6FB6D37E7E5A5F39235517BEB1F",
+        "SPDXRef-File--scripts-generate-spdx-design-sbom.py-F2A347983DC7A3FDFB9208BCD4766CADF7CCBD05",
+        "SPDXRef-File--cam-service-src-cam-byte-order.h-CFEE563CC5E62DC268996487B4C493D8BE77FF67",
+        "SPDXRef-File--cam-service-src-cam-service.c-123EC5C51BE94C6CA827224150CE9DFB50560D51",
+        "SPDXRef-File--cam-service-test-fixture-84085ddc-bc10-11ed-9a44-7ef9696e9dd0.csd-89E9678D98B0FC0EE2F9E9F767B164D365C8397A",
+        "SPDXRef-File--cam-service-test-src-test-suite.h-CDF9CDBFD5BBE73D030A9DF8D9665C5C35405A62",
+        "SPDXRef-File--.git-hooks-pre-push.sample-A599B773B930CA83DBC3A5C7C13059AC4A6EAEDC",
+        "SPDXRef-File--.git-hooks-commit-msg.sample-EE1ED5AAD98A435F2020B6DE35C173B75D9AFFAC",
+        "SPDXRef-File--.git-hooks-push-to-checkout.sample-508240328C8B55F8157C93C43BF5E291E5D2FBCB",
+        "SPDXRef-File--.git-logs-HEAD-A1463843B44FEA0BF52CD4297FC21E495862E40E",
+        "SPDXRef-File--cam-uuid-src-cam-uuid.c-5DEC9CB37B34642434C84774014D3C2DEF39F507",
+        "SPDXRef-File--libcam-src-cam.c-59D6C20D06B5D434F1FAD43D5CED2A11A5B9695C",
+        "SPDXRef-File--libcam-CMakeLists.txt-508BCE3E9654DD5D571CB8D90150585862FE2E15",
+        "SPDXRef-File--cam-tool-test-fixture-expected-msg-output-2-43816739F32FD401450F1528759953457B1EFE67",
+        "SPDXRef-File--cam-tool-test-fixture-expected-output.csc-9A700CBED8FE9BC368E0090B1526547434C41276",
+        "SPDXRef-File--cam-tool-test-fixture-empty-file.csc.yml-DA39A3EE5E6B4B0D3255BFEF95601890AFD80709",
+        "SPDXRef-File--cam-tool-test-fixture-expected-msg-output-3-CEC96F2A2E96DCFDD7FDEF02351F15327319943F",
+        "SPDXRef-File--cam-tool-test-test-cam-message.py-B02C92C2EDE06EC43605A4D5F26EF8782C644671",
+        "SPDXRef-File--cam-tool-cam-tool-cam-message.py-AF52202BD621892C4D0C374FCB87EB70F8E3324E",
+        "SPDXRef-File--test-fixture-99085ddc-bc10-11ed-9a44-7ef9696e0000.csc.yml-AEC52C1F0C022CD28C89CE74CD2F58B123CDB5C6",
+        "SPDXRef-File--test-test-config-deploy.py-E9D3FEF98F9501198DCB644A49E68B2323846E22",
+        "SPDXRef-File--.github-workflows-repo-sync.yml-997A90A371BB51F06A898A45B9DFD7243517875E",
+        "SPDXRef-File--.github-workflows-strictdoc-export.yml-28E30D129435BE2720AE8698E0AA1DE260374E8A",
+        "SPDXRef-File--docs-screencast-recordings-Introduction-Navigation-Recording.mp4-31986C4CDE5C1618B869675195AD67EEB5B4D378",
+        "SPDXRef-File--docs-strictdoc-evidence-EVID-008-future-timestamp-rejection.txt-708DA0856E63041F222573088402A4DD2430FBF1",
+        "SPDXRef-File--docs-strictdoc-06-verification-plan.sdoc-222C8219081AA7FABFCC5A004DB677153080A619",
+        "SPDXRef-File--docs-strictdoc-01-hara-lite.sdoc-60AD39D89246C86E24477722959BBC06363F7E16",
+        "SPDXRef-File--docs-demos-project-gearshift-demo-scenario-appsecurity-ghas.md-627EFF5DA7CBFC54615C036115E32798FF5FFD26",
+        "SPDXRef-File--documentation-images-cam-overview.svg-43A589CA729079E8A986BA477D6CA04B230B775C",
+        "SPDXRef-File--documentation-manual-file-csel.rst-F549E6C548D67CC78320C480B3C2201233026374",
+        "SPDXRef-File--.git-description-9635F1B7E12C045212819DD934D809EF07EFA2F4",
+        "SPDXRef-File--cam-uuid-test-src-test-suite.h-30E60F13DCD57065C8F3206914794786E9AEBFFF",
+        "SPDXRef-File--libcam-test-src-test-libcam.c-FA08DEF8E763F31C6890796AE23AE9477940648D",
+        "SPDXRef-File--cam-tool-test-fixture-expected-msg-output-0-42A4902AFCCC45A3244E7E48C58264B267D26275",
+        "SPDXRef-File--cam-tool-test-fixture-success-case.msg-rcv-531873E1E318A30E191041E59F1E926DCB1F375C",
+        "SPDXRef-File--cam-tool-test-fixture-no-meta-uuid.csc.yml-D094E5DF930C9EB40112BDA356567FE2C81F0CBF",
+        "SPDXRef-File--cam-tool-test-fixture-no-padding-bytes.csd-5737DEED8785E47DDAB3BA109B36A3C7B0637700",
+        "SPDXRef-File--cam-tool-test-fixture-valid.csc.yml-2713BBCB038082FB82094E01433F40DABC70BD39",
+        "SPDXRef-File--cam-tool-test---init--.py-99CC0AD65EE34E2C19C7BBE1B2E98783F60C5F26",
+        "SPDXRef-File--cam-tool-cam-tool-cam-csel.py-B744D0E19032DFCD5A818E1CB7D1F26B95BB9D69",
+        "SPDXRef-File--test-fixture-99085ddc-bc10-11ed-9a44-7ef9696e0001.csd-DECB406C982A00276FA967201C9B8331FBB8C8B6",
+        "SPDXRef-File--test-conftest.py-1CAFCFB361A995F4D9A342D260548E9F184C211D",
+        "SPDXRef-File--.github-workflows-Kronos-Latest.yaml-5637276E7856B01BF8E43E24F916D6B16E65356B",
+        "SPDXRef-File--.github-workflows-mainSBOMgen.yml-F0B7428A33CE80BE3FA3A2A8DB4FC5E847829350",
+        "SPDXRef-File--docs-strictdoc-evidence-EVID-009-csel-generation-and-analysis.txt-7B73F07346B04D25D4A18C4B1B780A0876D93492",
+        "SPDXRef-File--docs-strictdoc-evidence-EVID-011-protocol-header-handler-validation.txt-52CDDC675EC716E1D497915CB01CE0026506D515",
+        "SPDXRef-File--docs-strictdoc-09-trace-matrix.sdoc-B386FDCE09A2F51191FC15DDD0DFA1B4A330F1D0",
+        "SPDXRef-File--docs-strictdoc-README.md-29F540525AF57E8F3C885362231B0F5D98FC42FD",
+        "SPDXRef-File--docs-demos-README.md-6C5F2B7281974392451115F37581C6F9A4FDFEAD",
+        "SPDXRef-File--documentation-images-cam-components.svg-48EB74708336D066955B4810FCF33C5E8D356B43",
+        "SPDXRef-File--documentation-development-index.rst-F31BE237B430E33F3346DAE9C5E7D8CB6A5C608D",
+        "SPDXRef-File--documentation-CMakeLists.txt-2B74A3223044E50C4AAC16EC4AA4DBCA34EED324",
+        "SPDXRef-File--Dangerfile-0FF0B87CC10146DEA17C795E40C60B7A2B33AEF6",
+        "SPDXRef-File--requirements.txt-92F50CBE2B01F83F6A3E25BDDF2CEBEFF743A0E0",
+        "SPDXRef-File--documentation-development-validation.rst-8F4D47C8A2CE2C2A31B1463FD36C344533BA1426",
+        "SPDXRef-File--documentation-doxyfile.in-53C725FA349593DE2980031FF464EB191702DB64",
+        "SPDXRef-File--.DS-Store-4B84BEED4F4ACC6F98DCAF193C0A2BB05F533D9A",
+        "SPDXRef-File--README.md-A3163A0CAC9F443EDF625648EFE70C3D365E6CDB"
+      ]
+    }
+  ],
+  "externalDocumentRefs": [],
+  "relationships": [
+    {
+      "relationshipType": "DEPENDS_ON",
+      "relatedSpdxElement": "SPDXRef-Package-480871C937AB17B2CA00697B94806F3B668E9C726D662774832FD26A33E9C973",
+      "spdxElementId": "SPDXRef-RootPackage"
+    },
+    {
+      "relationshipType": "DEPENDS_ON",
+      "relatedSpdxElement": "SPDXRef-Package-997BB0F681869CA98D5667676CD5B68622673C2FEF7DC8A74C4063DC206A7218",
+      "spdxElementId": "SPDXRef-RootPackage"
+    },
+    {
+      "relationshipType": "DEPENDS_ON",
+      "relatedSpdxElement": "SPDXRef-Package-F891BD098C2683819984852B8A47264307A6F37C7CB948CEA205390A27FED40D",
+      "spdxElementId": "SPDXRef-RootPackage"
+    },
+    {
+      "relationshipType": "DEPENDS_ON",
+      "relatedSpdxElement": "SPDXRef-Package-4DEA190FC8CE8EE0F406A9FF1F755BA738B18B7A986FF9D7E7F3731248E81E75",
+      "spdxElementId": "SPDXRef-RootPackage"
+    },
+    {
+      "relationshipType": "DEPENDS_ON",
+      "relatedSpdxElement": "SPDXRef-Package-501BDE8C2898B8F7C7CE89A8E40E4EE4137C22696CD458B85DDC6F4C505B5C05",
+      "spdxElementId": "SPDXRef-RootPackage"
+    },
+    {
+      "relationshipType": "DEPENDS_ON",
+      "relatedSpdxElement": "SPDXRef-Package-3F012714C432ACDFE4FC4261380361E90457B9E6DA4933C8205A749D16624AD3",
+      "spdxElementId": "SPDXRef-RootPackage"
+    },
+    {
+      "relationshipType": "DEPENDS_ON",
+      "relatedSpdxElement": "SPDXRef-Package-608734958F785BCA948551853649C7FC98B52E5D2060EC426F90714C5A70228D",
+      "spdxElementId": "SPDXRef-RootPackage"
+    },
+    {
+      "relationshipType": "DEPENDS_ON",
+      "relatedSpdxElement": "SPDXRef-Package-25A88B0E02EA9C9A3AF567240D2E9383B7A0B6C2B0D847431A58F42A9C2D6779",
+      "spdxElementId": "SPDXRef-RootPackage"
+    },
+    {
+      "relationshipType": "DEPENDS_ON",
+      "relatedSpdxElement": "SPDXRef-Package-C99E2E1E6C0E9A26D42002AD18B5C4EC3DD2F09BF57BDC6A772477CFBC5B33D1",
+      "spdxElementId": "SPDXRef-RootPackage"
+    },
+    {
+      "relationshipType": "DEPENDS_ON",
+      "relatedSpdxElement": "SPDXRef-Package-87749F3F5444B22B14A14E3607A49BA23BCDAEDF24C51964277B625FD9FD4967",
+      "spdxElementId": "SPDXRef-RootPackage"
+    },
+    {
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-RootPackage",
+      "spdxElementId": "SPDXRef-DOCUMENT"
+    }
+  ],
+  "spdxVersion": "SPDX-2.2",
+  "dataLicense": "CC0-1.0",
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "name": "im-customers-arm/arm-critical-app-monitoring 1.0.0",
+  "documentNamespace": "https://sbom.infomagnus.com/im-customers-arm%2Farm-critical-app-monitoring/1.0.0/zCKdVwOrIEGUQdAOqdOAIg",
+  "creationInfo": {
+    "created": "2026-02-18T02:31:58Z",
+    "creators": [
+      "Organization: OwnerName",
+      "Tool: Microsoft.SBOMTool-4.1.5"
+    ]
+  },
+  "documentDescribes": [
+    "SPDXRef-RootPackage"
+  ]
+}


### PR DESCRIPTION
This pull request introduces improvements to stable SPDX ID handling during SPDX 2 to SPDX 3 conversions, and adds comprehensive test coverage for stable-ID conversion using fixtures. The main changes are focused on enhancing the conversion logic to support more robust ID extraction and validation, as well as automating the testing process for stable IDs.

Stable ID conversion improvements:

* The stable ID extraction logic in `SpdxConverter.java` now checks multiple possible ID getters (`getId`, `getSpdxId`, `getSpdxID`, `getLicenseId`) and falls back to a deterministic ID if none are valid, ensuring more reliable and comprehensive ID mapping during conversion. [[1]](diffhunk://#diff-6fa543c0acb0234e692adfc59d664c8b8f47e431bc1248d1c618c67ff29f3269L404-L414) [[2]](diffhunk://#diff-6fa543c0acb0234e692adfc59d664c8b8f47e431bc1248d1c618c67ff29f3269R418-L426)

Test coverage enhancements:

* Added a new test suite in `SpdxConverterTestV3.java` that auto-discovers SPDX 2 fixtures from the `testResources/spdx2tospdx3conversion` directory and verifies stable ID consistency across multiple conversion runs, improving regression coverage for ID stability.
* Introduced helper methods for fixture discovery, conversion, ID collection, and diff reporting in the test suite, making it easier to add new fixtures and diagnose ID mismatches.
* Updated the `README.md` to document the location and usage of stable-ID conversion fixtures, guiding contributors on how to extend test coverage.

Test infrastructure updates:

* Added new imports and constants in `SpdxConverterTestV3.java` to support fixture directory handling and test logic. [[1]](diffhunk://#diff-3e551689642cca58cdf3fd62df7f21f438cdf38600f6f30a51a4dec2aae7074eR14-R22) [[2]](diffhunk://#diff-3e551689642cca58cdf3fd62df7f21f438cdf38600f6f30a51a4dec2aae7074eR36) [[3]](diffhunk://#diff-3e551689642cca58cdf3fd62df7f21f438cdf38600f6f30a51a4dec2aae7074eR51)