### PR TITLE
Set release jar version from tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,11 @@ jobs:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
+      - name: Set version from tag
+        run: |
+          RAW_TAG="${{ inputs.tag_name }}"
+          VERSION="${RAW_TAG#v}"
+          mvn --batch-mode versions:set -DnewVersion="${VERSION}" -DgenerateBackupPoms=false
       - name: Build jar
         run: mvn --batch-mode -DskipTests package
       - name: Prepare release asset


### PR DESCRIPTION
This pull request updates the release workflow to automatically set the Maven project version based on the Git tag. This ensures that release artifacts are consistently versioned according to the tag used for the release.

Release workflow improvements:

* Added a step to extract the version number from the Git tag and set the Maven project version accordingly using the `versions:set` command. (`.github/workflows/release.yml`)