### PR TITLE
Feature/deterministic spdxid converson

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,8 +40,9 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       run: |
-        if [[ $SONAR_TOKEN != "" ]]; then
-           mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar
-        else
-           mvn --batch-mode --update-snapshots verify
-        fi
+          TEST_OPTS="-DtrimStackTrace=false -Dsurefire.printSummary=true -Dsurefire.useFile=false"
+          if [[ $SONAR_TOKEN != "" ]]; then
+            mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar $TEST_OPTS
+          else
+            mvn --batch-mode --update-snapshots test $TEST_OPTS
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,8 @@ jobs:
             echo "Jar not found: $JAR" >&2
             exit 1
           fi
-          ASSET=tools-java-${VERSION}.jar
+          RELEASE_VERSION="${VERSION%-SNAPSHOT}"
+          ASSET=tools-java-${RELEASE_VERSION}.jar
           cp "$JAR" "$ASSET"
           echo "asset=$ASSET" >> "$GITHUB_OUTPUT"
       - name: Upload release asset


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to improve Maven build and release processes. The main changes are focused on enhancing test output visibility during builds and ensuring release artifacts use the correct version naming.

**Build process improvements:**
- Added Maven test options (`-DtrimStackTrace=false -Dsurefire.printSummary=true -Dsurefire.useFile=false`) to improve test output visibility in CI logs and switched from `verify` to `test` for faster feedback during non-Sonar builds.

**Release artifact naming:**
- Modified the release workflow to strip the `-SNAPSHOT` suffix from the version when naming the release JAR asset, ensuring released files have clean, production-ready version numbers.